### PR TITLE
ISSUE #249 - impose a limit of the number of meshes in a supermesh

### DIFF
--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
@@ -28,7 +28,7 @@ using namespace repo::manipulator::modeloptimizer;
 auto defaultGraph = repo::core::model::RepoScene::GraphType::DEFAULT;
 
 static const size_t  REPO_MP_MAX_FACE_COUNT = 500000;
-static const size_t REPO_MP_MAX_MESHES_IN_SUPERMESH = 1000;
+static const size_t REPO_MP_MAX_MESHES_IN_SUPERMESH = 30000;
 
 MultipartOptimizer::MultipartOptimizer() :
 AbstractOptimizer()

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
@@ -28,6 +28,7 @@ using namespace repo::manipulator::modeloptimizer;
 auto defaultGraph = repo::core::model::RepoScene::GraphType::DEFAULT;
 
 static const size_t  REPO_MP_MAX_FACE_COUNT = 500000;
+static const size_t REPO_MP_MAX_MESHES_IN_SUPERMESH = 1000;
 
 MultipartOptimizer::MultipartOptimizer() :
 AbstractOptimizer()
@@ -498,9 +499,10 @@ void MultipartOptimizer::sortMeshes(
 				texturedFCount[mFormat][texID] = 0;
 			}
 			size_t faceCount = mesh->getFaces().size();
-			if (texturedFCount[mFormat][texID] + faceCount > REPO_MP_MAX_FACE_COUNT)
+			if (texturedFCount[mFormat][texID] + faceCount > REPO_MP_MAX_FACE_COUNT ||
+				texturedMeshes[mFormat][texID].back().size > REPO_MP_MAX_MESHES_IN_SUPERMESH)
 			{
-				//Exceed max face count, create another grouping entry for this format
+				//Exceed max face count or meshes, create another grouping entry for this format
 				texturedMeshes[mFormat][texID].push_back(std::set<repo::lib::RepoUUID>());
 				texturedFCount[mFormat][texID] = 0;
 			}
@@ -521,9 +523,10 @@ void MultipartOptimizer::sortMeshes(
 				meshFCount[mFormat] = 0;
 			}
 			size_t faceCount = mesh->getFaces().size();
-			if (meshFCount[mFormat] && meshFCount[mFormat] + faceCount > REPO_MP_MAX_FACE_COUNT)
+			if (meshFCount[mFormat] && meshFCount[mFormat] + faceCount > REPO_MP_MAX_FACE_COUNT ||
+				texturedMeshes[mFormat][texID].back().size > REPO_MP_MAX_MESHES_IN_SUPERMESH)
 			{
-				//Exceed max face count, create another grouping entry for this format
+				//Exceed max face count or meshes, create another grouping entry for this format
 				meshMap[mFormat].push_back(std::set<repo::lib::RepoUUID>());
 				meshFCount[mFormat] = 0;
 			}

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
@@ -500,7 +500,8 @@ void MultipartOptimizer::sortMeshes(
 			}
 			size_t faceCount = mesh->getFaces().size();
 			if (texturedFCount[mFormat][texID] + faceCount > REPO_MP_MAX_FACE_COUNT ||
-				texturedMeshes[mFormat][texID].back().size > REPO_MP_MAX_MESHES_IN_SUPERMESH)
+				texturedMeshes[mFormat][texID].size() > 0 && 
+				texturedMeshes[mFormat][texID].back().size() > REPO_MP_MAX_MESHES_IN_SUPERMESH)
 			{
 				//Exceed max face count or meshes, create another grouping entry for this format
 				texturedMeshes[mFormat][texID].push_back(std::set<repo::lib::RepoUUID>());
@@ -524,7 +525,8 @@ void MultipartOptimizer::sortMeshes(
 			}
 			size_t faceCount = mesh->getFaces().size();
 			if (meshFCount[mFormat] && meshFCount[mFormat] + faceCount > REPO_MP_MAX_FACE_COUNT ||
-				texturedMeshes[mFormat][texID].back().size > REPO_MP_MAX_MESHES_IN_SUPERMESH)
+				meshMap[mFormat].size() &&
+				meshMap[mFormat].back().size() > REPO_MP_MAX_MESHES_IN_SUPERMESH)
 			{
 				//Exceed max face count or meshes, create another grouping entry for this format
 				meshMap[mFormat].push_back(std::set<repo::lib::RepoUUID>());


### PR DESCRIPTION
Impose a limit number of meshes in a supermesh to prevent error where the supermesh exceed the size of mongo bson object