### PR TITLE
ISSUE #251 impose a maximum node limit and return error if exceeded

### DIFF
--- a/bouncer/src/repo/core/model/collection/repo_scene.h
+++ b/bouncer/src/repo/core/model/collection/repo_scene.h
@@ -58,6 +58,7 @@ namespace repo{
 				static const uint16_t REPO_SCENE_TEXTURE_BIT = 0x0001;
 				static const uint16_t REPO_SCENE_ENTITIES_BIT = 0x0002;
 				static const uint16_t REPO_SCENE_INVALID_MESH_BIT = 0x0003;
+				const static uint32_t REPO_SCENE_MAX_NODES = 1000000;
 			public:
 
 				/**
@@ -299,6 +300,14 @@ namespace repo{
 				std::string getDatabaseName() const
 				{
 					return databaseName;
+				}
+
+				/**
+				* Check if this scene exceeds the max amount of nodes
+				*/
+				bool exceedsMaximumNodes() const
+				{
+					return graph.nodesByUniqueID.size() > REPO_SCENE_MAX_NODES;
 				}
 
 				/**

--- a/bouncer/src/repo/core/model/collection/repo_scene.h
+++ b/bouncer/src/repo/core/model/collection/repo_scene.h
@@ -58,7 +58,7 @@ namespace repo{
 				static const uint16_t REPO_SCENE_TEXTURE_BIT = 0x0001;
 				static const uint16_t REPO_SCENE_ENTITIES_BIT = 0x0002;
 				static const uint16_t REPO_SCENE_INVALID_MESH_BIT = 0x0003;
-				const static uint32_t REPO_SCENE_MAX_NODES = 1000000;
+				const static uint32_t REPO_SCENE_MAX_NODES = 1030000;
 			public:
 
 				/**

--- a/bouncer/src/repo/error_codes.h
+++ b/bouncer/src/repo/error_codes.h
@@ -65,5 +65,7 @@
 #define REPOERR_UNSUPPORTED_FBX_VERSION 23
 //Unsupported file version (generic)
 #define REPOERR_UNSUPPORTED_VERSION 24
+//Exceed the maximum amount fo nodes
+#define REPOERR_MAX_NODES_EXCEEDED 25
 
 

--- a/bouncer/src/repo/manipulator/repo_manipulator.cpp
+++ b/bouncer/src/repo/manipulator/repo_manipulator.cpp
@@ -816,6 +816,12 @@ const repo::manipulator::modelconvertor::ModelImportConfig *config)
 			repoTrace << "model Imported, generating Repo Scene";
 			if ((scene = modelConvertor->generateRepoScene()))
 			{
+				if (scene->exceedsMaximumNodes()) {
+					delete scene;
+					error = REPOERR_MAX_NODES_EXCEEDED;
+					return nullptr;
+				}
+
 				if (!scene->getAllMeshes(repo::core::model::RepoScene::GraphType::DEFAULT).size()) {
 
 					delete scene;


### PR DESCRIPTION
This is to allow a better error message when the revision bson exceeds the mongo maximum size (16MB)

I don't have a model to test this so please check my maths:

1 UUID is 128bit (aka 16B)
the maximum amount of UUIDs we can hold in 16MB is 16*1024*1024 / 16 = 1048576

so I've set the limit to 1030000 (to give ~290KB for random stuff)