### PR TITLE
Issue 253 Fix sample project

### DIFF
--- a/tools/bouncer_worker/bouncer_worker.js
+++ b/tools/bouncer_worker/bouncer_worker.js
@@ -275,7 +275,7 @@
 						};
 						const dir = `${rootModelDir}/${toyFed}`;
 						console.log("import toy fed... ", dir);
-						importToy(dbConfig, dir, cmdDatabase, cmdDatabase, cmdModel, {tree: 1}).then(()=> {
+						importToy(dbConfig, dir, cmdDatabase, cmdDatabase, cmdProject, {tree: 1}).then(()=> {
 							callback({
 								value: reply.value,
 								database: cmdDatabase,

--- a/tools/bouncer_worker/bouncer_worker.js
+++ b/tools/bouncer_worker/bouncer_worker.js
@@ -274,7 +274,6 @@
 							writeConcern: conf.mongoimport && conf.mongoimport.writeConcern
 						};
 						const dir = `${rootModelDir}/${toyFed}`;
-						console.log("import toy fed... ", dir);
 						importToy(dbConfig, dir, cmdDatabase, cmdDatabase, cmdProject, {tree: 1}).then(()=> {
 							callback({
 								value: reply.value,

--- a/tools/bouncer_worker/bouncer_worker.js
+++ b/tools/bouncer_worker/bouncer_worker.js
@@ -165,6 +165,7 @@
 		let cmdDatabase;
 		let cmdProject;
 		let cmdArr = cmd.split(' ');
+		let toyFed = false;
 			
 		// Extract database and project information from command
 		try{
@@ -178,6 +179,7 @@
 					cmdFile = require(cmdArr[1]);
 					cmdDatabase = cmdFile.database;
 					cmdProject = cmdFile.project;
+					toyFed = cmdFile.toyFed;
 					break;
 				case "importToy":
 					cmdDatabase = cmdArr[1];
@@ -262,11 +264,32 @@
 				}
 				else
 				{
-					callback({
-						value: reply.value,
-						database: cmdDatabase,
-						project: cmdProject
-					}, true);
+					if(toyFed) {
+						
+						const dbConfig = {
+							username: conf.bouncer.username,
+							password: conf.bouncer.password,
+							dbhost: conf.bouncer.dbhost,
+							dbport: conf.bouncer.dbport,
+							writeConcern: conf.mongoimport && conf.mongoimport.writeConcern
+						};
+						const dir = `${rootModelDir}/${toyFed}`;
+						console.log("import toy fed... ", dir);
+						importToy(dbConfig, dir, cmdDatabase, cmdDatabase, cmdModel, {tree: 1}).then(()=> {
+							callback({
+								value: reply.value,
+								database: cmdDatabase,
+								project: cmdProject
+							}, true);
+						});
+					} else {
+					
+						callback({
+							value: reply.value,
+							database: cmdDatabase,
+							project: cmdProject
+						}, true);
+					}
 				}
 			}
 

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -199,13 +199,13 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 		});
 	}
 
-	const subModelNameToOldID = {
-		"Lego_House_Architecture" : "ae234e5d-3b75-4b8c-b461-7529d5bec583",
-		"Lego_House_Landscape" : "39b51fe5-0fcb-4734-8e10-d8088bec9d45",
-		"Lego_House_Structure" : "3749c3cc-375d-406a-9f0d-2d059e8e782f"
-	}; 
-
 	function renameGroups(db){
+
+		const subModelNameToOldID = {
+			"Lego_House_Architecture" : "ae234e5d-3b75-4b8c-b461-7529d5bec583",
+			"Lego_House_Landscape" : "39b51fe5-0fcb-4734-8e10-d8088bec9d45",
+			"Lego_House_Structure" : "3749c3cc-375d-406a-9f0d-2d059e8e782f"
+		}; 
 		
 		return new Promise((resolve, reject) => {
 

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -236,10 +236,10 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 					subModelPromise = Promise.resolve();
 				}
 				
-				subModelPromise.then(() => {
+				return subModelPromise.then(() => {
 					console.log("!!!!!!!!!!!! ID Mapping" , oldIdToNewId);
 	
-					collection.find().forEach(group => {
+					return collection.find().forEach(group => {
 						group.objects && group.objects.forEach(obj => {
 							const updateObjectPromises = [];
 							obj.account = database;
@@ -248,12 +248,14 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 							//one of the sub models instead of the id of the fed model itself
 							if(oldIdToNewId[project]) {
 								obj.model = oldIdToNewId[project];
+								console.log(group._id, " converted project to ", obj.model);
 							}
 							else {
 								obj.model = project;
 							}
 						});
-							
+						
+						console.log(group);
 						return collection.updateOne({ _id: group._id }, group);
 
 

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -218,9 +218,9 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 				if(setting.subModels) {
 					const subModelList = [];
 					setting.subModels.forEach((subModel) => {
-						subModelList.add(subModel.model);
+						subModelList.push(subModel.model);
 					});
-				
+					console.log("!!!!!!!!! sub model list", subModelList); 
 					db.collection("settings").find({_id: {$in: subModelList}}).forEach( (subModelSetting) => {
 						if(subModelNameToOldID[subModelSetting.name]) {
 							oldIdToNewId[subModelNameToOldID[subModelSetting.name]] = subModelSetting._id;
@@ -229,7 +229,7 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 				} 
 
 					
-				console.log("!!!!!!!!!!!!" , oldIdToNewId);
+				console.log("!!!!!!!!!!!! ID Mapping" , oldIdToNewId);
 
 				collection.find().forEach(group => {
 					group.objects && group.objects.forEach(obj => {

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -251,11 +251,11 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 								console.log(group._id, " converted project to ", obj.model);
 							}
 							else {
+								console.log("did not find grouping for ", project, oldIdToNewId);
 								obj.model = project;
 							}
 						});
 
-						console.log(group._id);
 						return collection.updateOne({ _id: group._id }, group);
 
 

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -91,7 +91,6 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 
 			promises.push(new Promise((resolve, reject) => {
 				var cmd = `mongoimport -j 8 --host ${hostString} --username ${dbUsername} --password ${dbPassword} --authenticationDatabase admin --db ${database} --collection ${collection} --writeConcern '${JSON.stringify(writeConcern)}' --file ${__dirname}/${modelDir}/${filename}`;
-				console.log(cmd);
 				require('child_process').exec(cmd,
 				{
 					cwd: __dirname
@@ -226,7 +225,6 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 					subModelPromise.then((arr) => {
 						arr.forEach( (subModelSetting) => {
 							if(subModelNameToOldID[subModelSetting.name]) {
-								console.log(subModelSetting.name, subModelSetting._id, "=>", subModelSetting._id);
 								oldIdToNewId[subModelNameToOldID[subModelSetting.name]] = subModelSetting._id;
 							}
 						});
@@ -237,8 +235,6 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 				}
 				
 				return subModelPromise.then(() => {
-					console.log("!!!!!!!!!!!! ID Mapping" , oldIdToNewId);
-	
 					return collection.find().forEach(group => {
 						group.objects && group.objects.forEach(obj => {
 							const updateObjectPromises = [];
@@ -248,10 +244,8 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 							//one of the sub models instead of the id of the fed model itself
 							if(oldIdToNewId[obj.model]) {
 								obj.model = oldIdToNewId[obj.model];
-								console.log(group._id, " converted project to ", obj.model);
 							}
 							else {
-								console.log("did not find grouping for ",obj.model, oldIdToNewId);
 								obj.model = project;
 							}
 						});

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -213,7 +213,7 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 			const collection = db.collection(`${project}.groups`);
 
 
-			return db.collection("settings").find({_id: project}).then(setting => {
+			return db.collection("settings").findOne({_id: project}).then(setting => {
 				const oldIdToNewId = {};
 				if(setting.subModels) {
 					const subModelList = [];

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -91,6 +91,7 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 
 			promises.push(new Promise((resolve, reject) => {
 				var cmd = `mongoimport -j 8 --host ${hostString} --username ${dbUsername} --password ${dbPassword} --authenticationDatabase admin --db ${database} --collection ${collection} --writeConcern '${JSON.stringify(writeConcern)}' --file ${__dirname}/${modelDir}/${filename}`;
+				console.log(cmd);
 				require('child_process').exec(cmd,
 				{
 					cwd: __dirname
@@ -221,7 +222,6 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 					setting.subModels.forEach((subModel) => {
 						subModelList.push(subModel.model);
 					});
-					console.log("!!!!!!!!! sub model list", subModelList); 
 					subModelPromise = db.collection("settings").find({_id: {$in: subModelList}}).toArray();
 					subModelPromise.then((arr) => {
 						arr.forEach( (subModelSetting) => {
@@ -255,8 +255,7 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 							}
 						});
 
-						if(oldIdToNewId.length)
-							console.log(group);
+						console.log(group._id);
 						return collection.updateOne({ _id: group._id }, group);
 
 

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -246,12 +246,12 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 					
 							//if model is fed model, then model id of a group should be 
 							//one of the sub models instead of the id of the fed model itself
-							if(oldIdToNewId[project]) {
-								obj.model = oldIdToNewId[project];
+							if(oldIdToNewId[obj.model]) {
+								obj.model = oldIdToNewId[obj.model];
 								console.log(group._id, " converted project to ", obj.model);
 							}
 							else {
-								console.log("did not find grouping for ", project, oldIdToNewId);
+								console.log("did not find grouping for ",obj.model, oldIdToNewId);
 								obj.model = project;
 							}
 						});

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -217,7 +217,7 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 				const oldIdToNewId = {};
 				if(setting.subModels) {
 					const subModelList = [];
-					setting.subModelList.forEach((subModel) => {
+					setting.subModels.forEach((subModel) => {
 						subModelList.add(subModel.model);
 					});
 				

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -84,7 +84,6 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 		let writeConcern = dbConfig.writeConcern || {w: 1};
 
 		//mongoimport all json first
-		console.log(importCollectionFiles);
 
 		Object.keys(importCollectionFiles).forEach(collection => {
 
@@ -92,7 +91,6 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 
 			promises.push(new Promise((resolve, reject) => {
 				var cmd = `mongoimport -j 8 --host ${hostString} --username ${dbUsername} --password ${dbPassword} --authenticationDatabase admin --db ${database} --collection ${collection} --writeConcern '${JSON.stringify(writeConcern)}' --file ${__dirname}/${modelDir}/${filename}`;
-				console.log(cmd);
 				require('child_process').exec(cmd,
 				{
 					cwd: __dirname
@@ -201,6 +199,12 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 		});
 	}
 
+	const subModelNameToOldID = {
+		"Lego_House_Architecture" : "ae234e5d-3b75-4b8c-b461-7529d5bec583",
+		"Lego_House_Landscape" : "39b51fe5-0fcb-4734-8e10-d8088bec9d45",
+		"Lego_House_Structure" : "3749c3cc-375d-406a-9f0d-2d059e8e782f"
+	}; 
+
 	function renameGroups(db){
 		
 		return new Promise((resolve, reject) => {
@@ -208,62 +212,56 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 			const updateGroupPromises = [];
 			const collection = db.collection(`${project}.groups`);
 
-			collection.find().forEach(group => {
 
-				group.objects && group.objects.forEach(obj => {
+			return db.collection("settings").find({_id: project}).then(setting => {
+				const oldIdToNewId = {};
+				if(setting.subModels) {
+					const subModelList = [];
+					setting.subModelList.forEach((subModel) => {
+						subModelList.add(subModel.model);
+					});
+				
+					db.collection("settings").find({_id: {$in: subModelList}}).forEach( (subModelSetting) => {
+						if(subModelNameToOldID[subModelSetting.name]) {
+							oldIdToNewId[subModelNameToOldID[subModelSetting.name]] = subModelSetting._id;
+						}
+					});
+				} 
 
-					const updateObjectPromises = [];
-					obj.account = database;
-					obj.model = project;
 					
-					//if model is fed model, then model id of a group should be 
-					//one of the sub models instead of the id of the fed model itself
-					updateObjectPromises.push(
-						db.collection('settings').findOne({ _id: project }).then(setting => {
-							const subModels = setting.subModels;
-							if(subModels && subModels.length){
-								return Promise.all(
-									subModels.map(subModel => { 
-										if(obj.ifc_guids) {
-											const query = { type: "meta", "metadata.IFC GUID": {$in : obj.ifc_guids} };
-											const col = `${subModel.model}.scene`;
-											return db.collection(col).count(query).then(count => {
-												if(count){
-													obj.model = subModel.model;
-												}
-											})
-										} else if(obj.shared_ids) {
-											return db.collection(`${subModel.model}.scene`).count({ shared_id: {$in: obj.shared_ids} }).then(count => {
-												if(count) {
-													obj.model = subModel.model;
-												}
-											});
-										}
-									})
-								);
-							}
+				console.log("!!!!!!!!!!!!" , oldIdToNewId);
 
-						})
-					);					
+				collection.find().forEach(group => {
+					group.objects && group.objects.forEach(obj => {
+						const updateObjectPromises = [];
+						obj.account = database;
+					
+						//if model is fed model, then model id of a group should be 
+						//one of the sub models instead of the id of the fed model itself
+						if(oldIdToNewId[project]) {
+							obj.model = oldIdToNewId[project];
+						}
+						else {
+							obj.model = project;
+						}
+					});
+						
+					return collection.updateOne({ _id: group._id }, group);
 
-					updateGroupPromises.push(
-						Promise.all(updateObjectPromises).then(() => {
-							collection.updateOne({
-							_id: group._id }, group)
-						})
-					);
 
+				}, function done(err) {
+					if(err){
+						reject(err);
+					} else {
+						Promise.all(updateGroupPromises)
+							.then(() => resolve())
+							.catch(err => reject(err));
+					}
 				});
 
-			}, function done(err) {
-				if(err){
-					reject(err);
-				} else {
-					Promise.all(updateGroupPromises)
-						.then(() => resolve())
-						.catch(err => reject(err));
-				}
+
 			});
+			
 		});
 
 	}
@@ -296,7 +294,6 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 				unityAsset.database = database;
 				unityAsset.model = project;
 
-				//console.log(unityAsset);
 
 				//drop the old one
 				bucket.delete(file._id, function(err){
@@ -312,7 +309,6 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 						if(err){
 							reject(err)
 						} else {
-							//console.log('finish writing to file' + file._id)
 							resolve();
 						}
 					});

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -222,8 +222,8 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 					});
 					console.log("!!!!!!!!! sub model list", subModelList); 
 					db.collection("settings").find({_id: {$in: subModelList}}).forEach( (subModelSetting) => {
-						console.log(subModelSetting.name, subModelSetting._id);
 						if(subModelNameToOldID[subModelSetting.name]) {
+							console.log(subModelSetting.name, subModelSetting._id, "=>", subModelSetting._id);
 							oldIdToNewId[subModelNameToOldID[subModelSetting.name]] = subModelSetting._id;
 						}
 					});

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -215,19 +215,26 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 
 			return db.collection("settings").findOne({_id: project}).then(setting => {
 				const oldIdToNewId = {};
+				let subModelPromise;
 				if(setting.subModels) {
 					const subModelList = [];
 					setting.subModels.forEach((subModel) => {
 						subModelList.push(subModel.model);
 					});
 					console.log("!!!!!!!!! sub model list", subModelList); 
-					db.collection("settings").find({_id: {$in: subModelList}}).forEach( (subModelSetting) => {
-						if(subModelNameToOldID[subModelSetting.name]) {
-							console.log(subModelSetting.name, subModelSetting._id, "=>", subModelSetting._id);
-							oldIdToNewId[subModelNameToOldID[subModelSetting.name]] = subModelSetting._id;
-						}
+					subModelPromise = db.collection("settings").find({_id: {$in: subModelList}}).toArray();
+					subModelPromise.then((arr) => {
+						arr.forEach( (subModelSetting) => {
+							if(subModelNameToOldID[subModelSetting.name]) {
+								console.log(subModelSetting.name, subModelSetting._id, "=>", subModelSetting._id);
+								oldIdToNewId[subModelNameToOldID[subModelSetting.name]] = subModelSetting._id;
+							}
+						});
 					});
 				} 
+				else {
+					subModelPromise = Promise.resolve();
+				}
 
 					
 				console.log("!!!!!!!!!!!! ID Mapping" , oldIdToNewId);

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -254,8 +254,9 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 								obj.model = project;
 							}
 						});
-						
-						console.log(group);
+
+						if(oldIdToNewId.length)
+							console.log(group);
 						return collection.updateOne({ _id: group._id }, group);
 
 

--- a/tools/bouncer_worker/importToy.js
+++ b/tools/bouncer_worker/importToy.js
@@ -222,6 +222,7 @@ module.exports = function(dbConfig, modelDir, username, database, project, skipP
 					});
 					console.log("!!!!!!!!! sub model list", subModelList); 
 					db.collection("settings").find({_id: {$in: subModelList}}).forEach( (subModelSetting) => {
+						console.log(subModelSetting.name, subModelSetting._id);
 						if(subModelNameToOldID[subModelSetting.name]) {
 							oldIdToNewId[subModelNameToOldID[subModelSetting.name]] = subModelSetting._id;
 						}

--- a/tools/bouncer_worker/package.json
+++ b/tools/bouncer_worker/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "start": "pm2 start bouncer_worker.js",
-    "stop": "pm2 stop bouncer_worker.js",
+    "stop": "pm2 kill",
     "restart": "npm stop; npm start"
   },
   "dependencies": {


### PR DESCRIPTION
This PR fixes #253 

**Problem:**
Sample project federation's groups doesn't always work.

**Why:**
As it stands, the model ID within the object array of groups are updated when we call importToy on the federation model. This is done by looking through the database of the sub models listed and see, for each ID,whether we can find the objects indicated within the submodels, if we find one, then we rename the obj.model to that sub model, otherwise, we leave it as federation ID.

This is a problem because:
- The process can happen before the sub model has been fully imported, thus the objects may not exist in the subModel
- The process can happen before the federation has been federated.

**Fix:**
- Instead of looking for the objects, we store a mapping of old model ID to model name, so we can figure out the old model ID to new model ID, and use this mapping instead of looking through sub models for imported object IDs that may not exists.

- Only perform importToy on federation once the federation generation has been completed.