### PR TITLE
Issue 260 - ensure sample project generates trees for all revisions

### DIFF
--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -21,10 +21,12 @@
 
 #include <sstream>
 #include <fstream>
+#include <algorithm>
 
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/filesystem.hpp>
+
 
 static const std::string FBX_EXTENSION = ".FBX";
 
@@ -364,19 +366,14 @@ int32_t generateStash(
 
 	bool branch = true;
 	std::string revId = REPO_HISTORY_MASTER_BRANCH;
-	bool generateAll = false;
 	if (command.nArgcs > 3) {
-		if (generateAll = command.args[3] == "all") {
-			repoLog("Regenerating all trees");
-		} else {
-			branch = false;
-			revId = command.args[3];
-		}
-
+		revId = command.args[3];
 	}
 
 	bool success = true;
-	if (generateAll)
+	std::string revToLower = revId;
+	std::transform(revToLower.begin(), revToLower.end(), revToLower.begin(), ::tolower);
+	if (revToLower == "all")
 	{
 		auto revs = controller->getAllFromCollectionContinuous(token, dbName, project + ".history");
 		for (const auto &rev : revs) {

--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -308,31 +308,30 @@ bool _generateStash(
 
 	repoLog("Generating stash of type " + type + " for " + dbName + "." + project + " rev: " + revID + (isBranch ? " (branch ID)" : ""));
 	auto scene = controller->fetchScene(token, dbName, project, revID, isBranch, false, true, type == "tree");
-	if (!scene)
-	{
-		return REPOERR_STASH_GEN_FAIL;
-	}
-
 	bool  success = false;
+	if (scene) {
+		if (type == "repo")
+		{
+			success = controller->generateAndCommitStashGraph(token, scene);
+		}
+		else if (type == "gltf")
+		{
+			success = controller->generateAndCommitGLTFBuffer(token, scene);
+		}
+		else if (type == "src")
+		{
+			success = controller->generateAndCommitSRCBuffer(token, scene);
+		}
+		else if (type == "tree")
+		{
+			success = controller->generateAndCommitSelectionTree(token, scene);
+		}
+		
+		delete scene;
+	}
 
-	if (type == "repo")
-	{
-		success = controller->generateAndCommitStashGraph(token, scene);
-	}
-	else if (type == "gltf")
-	{
-		success = controller->generateAndCommitGLTFBuffer(token, scene);
-	}
-	else if (type == "src")
-	{
-		success = controller->generateAndCommitSRCBuffer(token, scene);
-	}
-	else if (type == "tree")
-	{
-		success = controller->generateAndCommitSelectionTree(token, scene);
-	}
 
-	delete scene;
+
 	return success;
 }
 

--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -368,6 +368,7 @@ int32_t generateStash(
 	std::string revId = REPO_HISTORY_MASTER_BRANCH;
 	if (command.nArgcs > 3) {
 		revId = command.args[3];
+		branch = false;
 	}
 
 	bool success = true;

--- a/tools/bouncer_worker/bouncer_worker.js
+++ b/tools/bouncer_worker/bouncer_worker.js
@@ -107,7 +107,7 @@
 						project: model
 					}), true);
 				} else {
-					exeCommand(`genStash ${database} ${model} tree`, rid, callback);
+					exeCommand(`genStash ${database} ${model} tree all`, rid, callback);
 				}
 				
 			}).catch(err => {


### PR DESCRIPTION
This fixes #260 and https://github.com/3drepo/3drepo.io/issues/1042

Problem Pavol had was because we only re-generate the tree for the latest revision (regeneration of tree is needed to ensure the modelID and the teamspace name is correct), meaning the tree is effectively broken if you try to load any older revisions.

This is fixed by ensuring we generate all trees for all revisions when we import the sample project.