### PR TITLE
ISSUE #269 fix check that checks if texture exists

### DIFF
--- a/bouncer/src/repo/core/model/bson/repo_node_texture.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_node_texture.cpp
@@ -42,7 +42,7 @@ TextureNode::~TextureNode()
 std::vector<char> TextureNode::getRawData() const
 {
 	std::vector<char> dataVec;
-	if (hasField(REPO_LABEL_DATA))
+	if (hasBinField(REPO_LABEL_DATA))
 	{
 		getBinaryFieldAsVector(REPO_LABEL_DATA, dataVec);
 	}


### PR DESCRIPTION
this resolves #269 

Current check for texture only checks if the property `data` exists. If the texture is beyond ~15MB then it is currently stored in gridFS, meaning it wouldn't have a data field within the BSON object - thus it would think there is no texture.

Test case:
- uploading a model with a big texture file should now work (kind of)