### PR TITLE
Issue 276 - IFC shininess tweaks

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_ifc_utils_geometry.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_ifc_utils_geometry.cpp
@@ -56,14 +56,14 @@ repo_material_t IFCUtilsGeometry::createMaterial(
 
 	if (material.hasSpecularity())
 	{
-		matProp.shininess = material.specularity() / 128.;
+		matProp.shininess = material.specularity() / 256;
 	}
 	else
 	{
 		matProp.shininess = 0.5;
 	}
 
-	matProp.shininessStrength = 1;
+	matProp.shininessStrength = 0.5;
 
 	if (material.hasTransparency())
 	{


### PR DESCRIPTION
This resolves #276 
Halving the specularity strength and shininess value to reduce crazy mirrored effect on IFC models