### PR TITLE
Issue 279 - return no mesh error instead of unknown error if no mesh from dgn

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_dgn.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_dgn.cpp
@@ -30,9 +30,9 @@ repo::core::model::RepoScene* DgnModelImport::generateRepoScene()
 	repo::core::model::RepoScene *scene = nullptr;
 #ifdef ODA_SUPPORT
 	repoInfo << "Constructing Repo Scene...";
+	const repo::core::model::RepoNodeSet dummy;
 	auto meshSet = geoCollector.getMeshNodes();
-	if (meshSet.size()) {
-		const repo::core::model::RepoNodeSet dummy;
+	if (!meshSet.size()) {
 		repoInfo << "Get material nodes... ";
 		auto matSet =  geoCollector.getMaterialNodes();
 		auto transSet = geoCollector.getTransformationNodes();
@@ -42,6 +42,7 @@ repo::core::model::RepoScene* DgnModelImport::generateRepoScene()
 	}
 	else {
 		repoError << "No meshes generated";
+		scene = new repo::core::model::RepoScene({ filePath }, dummy, dummy, dummy, dummy, dummy, dummy);
 	}
 	
 #endif

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_dgn.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_dgn.cpp
@@ -32,7 +32,7 @@ repo::core::model::RepoScene* DgnModelImport::generateRepoScene()
 	repoInfo << "Constructing Repo Scene...";
 	const repo::core::model::RepoNodeSet dummy;
 	auto meshSet = geoCollector.getMeshNodes();
-	if (!meshSet.size()) {
+	if (meshSet.size()) {
 		repoInfo << "Get material nodes... ";
 		auto matSet =  geoCollector.getMaterialNodes();
 		auto transSet = geoCollector.getTransformationNodes();


### PR DESCRIPTION
- should return no mesh found error message instead of unknown error on dgn imports that failed with no meshes.

I didn't have any files with no mesh (tried to get one from the business guys but no luck yet), so I only tested this by hacking the if condition...