### PR TITLE
ISSUE #289 toy project fix : export risks/views

### DIFF
--- a/tools/bouncer_worker/exportToy.py
+++ b/tools/bouncer_worker/exportToy.py
@@ -37,7 +37,7 @@ for model in modelList:
         os.system(cmd)
 
 #only export groups and issues from federation
-colsInFed = ["groups", "issues"]
+colsInFed = ["groups", "issues", "risks", "views"]
 
 modelDirectory = "toy/" + fedID
 if not os.path.exists(modelDirectory):

--- a/tools/bouncer_worker/exportToy.py
+++ b/tools/bouncer_worker/exportToy.py
@@ -36,7 +36,7 @@ for model in modelList:
         cmd =  "mongoexport /host:" + dbAdd + " /port:" + dbPort + " /username:" + dbUsername + " /password:" + dbPassword + " /authenticationDatabase:admin /db:" + dbName + " /collection:" + model + "." + ext  + " /out:" + modelDirectory + "/"  + ext + ".json";
         os.system(cmd)
 
-#only export groups and issues from federation
+#export groups, issues, risks, and views from federation
 colsInFed = ["groups", "issues", "risks", "views"]
 
 modelDirectory = "toy/" + fedID


### PR DESCRIPTION
I forgot to change the script to export risks/views from the toy project federation, so all the toy projects imported had no risks/views.

`exportToy.js` is used on a set of sample models to do a mongoexport to retrieve mongo dumps for future toy project imports

There's an update to the zip file of the export, also relies on a change on https://github.com/3drepo/3drepo.io/issues/1263 to see the risks