### PR TITLE
Issue 298 - Speed up optimiser

### DIFF
--- a/bouncer/src/repo/core/model/bson/repo_node_mesh.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_node_mesh.cpp
@@ -43,116 +43,120 @@ MeshNode::~MeshNode()
 RepoNode MeshNode::cloneAndApplyTransformation(
 	const repo::lib::RepoMatrix &matrix) const
 {
-	std::vector<repo::lib::RepoVector3D> vertices = getVertices();
-	std::vector<repo::lib::RepoVector3D> normals = getNormals();
+	if (!matrix.isIdentity()) {
+		std::vector<repo::lib::RepoVector3D> vertices = getVertices();
+		std::vector<repo::lib::RepoVector3D> normals = getNormals();
 
-	auto newBigFiles = bigFiles;
+		auto newBigFiles = bigFiles;
 
-	RepoBSONBuilder builder;
-	std::vector<repo::lib::RepoVector3D> resultVertice;
-	std::vector<repo::lib::RepoVector3D> newBbox;
-	if (vertices.size())
-	{
-		resultVertice.reserve(vertices.size());
-		for (const repo::lib::RepoVector3D &v : vertices)
+		RepoBSONBuilder builder;
+		std::vector<repo::lib::RepoVector3D> resultVertice;
+		std::vector<repo::lib::RepoVector3D> newBbox;
+		if (vertices.size())
 		{
-			resultVertice.push_back(matrix * v);
-			if (newBbox.size())
+			resultVertice.reserve(vertices.size());
+			for (const repo::lib::RepoVector3D &v : vertices)
 			{
-				if (resultVertice.back().x < newBbox[0].x)
-					newBbox[0].x = resultVertice.back().x;
+				resultVertice.push_back(matrix * v);
+				if (newBbox.size())
+				{
+					if (resultVertice.back().x < newBbox[0].x)
+						newBbox[0].x = resultVertice.back().x;
 
-				if (resultVertice.back().y < newBbox[0].y)
-					newBbox[0].y = resultVertice.back().y;
+					if (resultVertice.back().y < newBbox[0].y)
+						newBbox[0].y = resultVertice.back().y;
 
-				if (resultVertice.back().z < newBbox[0].z)
-					newBbox[0].z = resultVertice.back().z;
+					if (resultVertice.back().z < newBbox[0].z)
+						newBbox[0].z = resultVertice.back().z;
 
-				if (resultVertice.back().x > newBbox[1].x)
-					newBbox[1].x = resultVertice.back().x;
+					if (resultVertice.back().x > newBbox[1].x)
+						newBbox[1].x = resultVertice.back().x;
 
-				if (resultVertice.back().y > newBbox[1].y)
-					newBbox[1].y = resultVertice.back().y;
+					if (resultVertice.back().y > newBbox[1].y)
+						newBbox[1].y = resultVertice.back().y;
 
-				if (resultVertice.back().z > newBbox[1].z)
-					newBbox[1].z = resultVertice.back().z;
+					if (resultVertice.back().z > newBbox[1].z)
+						newBbox[1].z = resultVertice.back().z;
+				}
+				else
+				{
+					newBbox.push_back(resultVertice.back());
+					newBbox.push_back(resultVertice.back());
+				}
+			}
+			if (newBigFiles.find(REPO_NODE_MESH_LABEL_VERTICES) != newBigFiles.end())
+			{
+				const uint64_t verticesByteCount = resultVertice.size() * sizeof(repo::lib::RepoVector3D);
+				newBigFiles[REPO_NODE_MESH_LABEL_VERTICES].second.resize(verticesByteCount);
+				memcpy(newBigFiles[REPO_NODE_MESH_LABEL_VERTICES].second.data(), resultVertice.data(), verticesByteCount);
 			}
 			else
+				builder.appendBinary(REPO_NODE_MESH_LABEL_VERTICES, resultVertice.data(), resultVertice.size() * sizeof(repo::lib::RepoVector3D));
+
+			if (normals.size())
 			{
-				newBbox.push_back(resultVertice.back());
-				newBbox.push_back(resultVertice.back());
+				auto matInverse = matrix.invert();
+				auto worldMat = matInverse.transpose();
+
+				std::vector<repo::lib::RepoVector3D> resultNormals;
+				resultNormals.reserve(normals.size());
+
+				auto data = worldMat.getData();
+				data[3] = data[7] = data[11] = 0;
+				data[12] = data[13] = data[14] = 0;
+
+				repo::lib::RepoMatrix multMat(data);
+
+				for (const repo::lib::RepoVector3D &v : normals)
+				{
+					auto transformedNormal = multMat * v;
+					transformedNormal.normalize();
+					resultNormals.push_back(transformedNormal);
+				}
+
+				if (newBigFiles.find(REPO_NODE_MESH_LABEL_NORMALS) != newBigFiles.end())
+				{
+					const uint64_t byteCount = resultNormals.size() * sizeof(repo::lib::RepoVector3D);
+					newBigFiles[REPO_NODE_MESH_LABEL_NORMALS].second.resize(byteCount);
+					memcpy(newBigFiles[REPO_NODE_MESH_LABEL_NORMALS].second.data(), resultNormals.data(), byteCount);
+				}
+				else
+					builder.appendBinary(REPO_NODE_MESH_LABEL_NORMALS, resultNormals.data(), resultNormals.size() * sizeof(repo::lib::RepoVector3D));
 			}
-		}
-		if (newBigFiles.find(REPO_NODE_MESH_LABEL_VERTICES) != newBigFiles.end())
-		{
-			const uint64_t verticesByteCount = resultVertice.size() * sizeof(repo::lib::RepoVector3D);
-			newBigFiles[REPO_NODE_MESH_LABEL_VERTICES].second.resize(verticesByteCount);
-			memcpy(newBigFiles[REPO_NODE_MESH_LABEL_VERTICES].second.data(), resultVertice.data(), verticesByteCount);
+
+			RepoBSONBuilder arrayBuilder, outlineBuilder;
+			for (size_t i = 0; i < newBbox.size(); ++i)
+			{
+				std::vector<float> boundVec = { newBbox[i].x, newBbox[i].y, newBbox[i].z };
+				arrayBuilder.appendArray(std::to_string(i), boundVec);
+			}
+
+			if (newBbox[0].x > newBbox[1].x || newBbox[0].z > newBbox[1].z || newBbox[0].y > newBbox[1].y)
+			{
+				repoError << "New bounding box is incorrect!!!";
+			}
+			builder.appendArray(REPO_NODE_MESH_LABEL_BOUNDING_BOX, arrayBuilder.obj());
+
+			std::vector<float> outline0 = { newBbox[0].x, newBbox[0].y };
+			std::vector<float> outline1 = { newBbox[1].x, newBbox[0].y };
+			std::vector<float> outline2 = { newBbox[1].x, newBbox[1].y };
+			std::vector<float> outline3 = { newBbox[0].x, newBbox[1].y };
+			outlineBuilder.appendArray("0", outline0);
+			outlineBuilder.appendArray("1", outline1);
+			outlineBuilder.appendArray("2", outline2);
+			outlineBuilder.appendArray("3", outline3);
+			builder.appendArray(REPO_NODE_MESH_LABEL_OUTLINE, outlineBuilder.obj());
+
+			return MeshNode(builder.appendElementsUnique(*this), newBigFiles);
 		}
 		else
-			builder.appendBinary(REPO_NODE_MESH_LABEL_VERTICES, resultVertice.data(), resultVertice.size() * sizeof(repo::lib::RepoVector3D));
-
-		if (normals.size())
 		{
-			auto matInverse = matrix.invert();
-			auto worldMat = matInverse.transpose();
-
-			std::vector<repo::lib::RepoVector3D> resultNormals;
-			resultNormals.reserve(normals.size());
-
-			auto data = worldMat.getData();
-			data[3] = data[7] = data[11] = 0;
-			data[12] = data[13] = data[14] = 0;
-
-			repo::lib::RepoMatrix multMat(data);
-
-			for (const repo::lib::RepoVector3D &v : normals)
-			{
-				auto transformedNormal = multMat * v;
-				transformedNormal.normalize();
-				resultNormals.push_back(transformedNormal);
-			}
-
-			if (newBigFiles.find(REPO_NODE_MESH_LABEL_NORMALS) != newBigFiles.end())
-			{
-				const uint64_t byteCount = resultNormals.size() * sizeof(repo::lib::RepoVector3D);
-				newBigFiles[REPO_NODE_MESH_LABEL_NORMALS].second.resize(byteCount);
-				memcpy(newBigFiles[REPO_NODE_MESH_LABEL_NORMALS].second.data(), resultNormals.data(), byteCount);
-			}
-			else
-				builder.appendBinary(REPO_NODE_MESH_LABEL_NORMALS, resultNormals.data(), resultNormals.size() * sizeof(repo::lib::RepoVector3D));
+			repoError << "Unable to apply transformation: Cannot find vertices within a mesh!";
+			return  RepoNode(this->copy(), bigFiles);
 		}
-
-		RepoBSONBuilder arrayBuilder, outlineBuilder;
-		for (size_t i = 0; i < newBbox.size(); ++i)
-		{
-			std::vector<float> boundVec = { newBbox[i].x, newBbox[i].y, newBbox[i].z };
-			arrayBuilder.appendArray(std::to_string(i), boundVec);
-		}
-
-		if (newBbox[0].x > newBbox[1].x || newBbox[0].z > newBbox[1].z || newBbox[0].y > newBbox[1].y)
-		{
-			repoError << "New bounding box is incorrect!!!";
-		}
-		builder.appendArray(REPO_NODE_MESH_LABEL_BOUNDING_BOX, arrayBuilder.obj());
-
-		std::vector<float> outline0 = { newBbox[0].x, newBbox[0].y };
-		std::vector<float> outline1 = { newBbox[1].x, newBbox[0].y };
-		std::vector<float> outline2 = { newBbox[1].x, newBbox[1].y };
-		std::vector<float> outline3 = { newBbox[0].x, newBbox[1].y };
-		outlineBuilder.appendArray("0", outline0);
-		outlineBuilder.appendArray("1", outline1);
-		outlineBuilder.appendArray("2", outline2);
-		outlineBuilder.appendArray("3", outline3);
-		builder.appendArray(REPO_NODE_MESH_LABEL_OUTLINE, outlineBuilder.obj());
-
-		return MeshNode(builder.appendElementsUnique(*this), newBigFiles);
-	}
-	else
-	{
-		repoError << "Unable to apply transformation: Cannot find vertices within a mesh!";
-		return  RepoNode(this->copy(), bigFiles);
-	}
+	} 
+	RepoBSONBuilder builder;
+	return MeshNode(builder.appendElementsUnique(*this), bigFiles);
 }
 
 MeshNode MeshNode::cloneAndUpdateMeshMapping(

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_trans_reduction.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_trans_reduction.cpp
@@ -133,17 +133,20 @@ void TransformationReductionOptimizer::applyOptimOnMesh(
 				std::vector<repo::core::model::RepoNode*> meshVector, metaVector;
 				int transSiblingCount = 0;
 
-				for (auto *child : children) {
-
-					if (child->getTypeAsEnum() == repo::core::model::NodeType::TRANSFORMATION) {
-						++transSiblingCount;
-					}
-					else if (child->getTypeAsEnum() == repo::core::model::NodeType::MESH){
-						meshVector.push_back(child);
-					}
-					else if (child->getTypeAsEnum() == repo::core::model::NodeType::METADATA) {
-						metaVector.push_back(child);
-					}
+				for (auto *child : children)
+				{
+					switch (child->getTypeAsEnum())
+					{
+						case repo::core::model::NodeType::TRANSFORMATION:
+							++transSiblingCount;
+							break;
+						case repo::core::model::NodeType::MESH:
+							meshVector.push_back(child);
+							break;
+						case repo::core::model::NodeType::METADATA:
+							metaVector.push_back(child);
+							break;
+					}					
 				}
 
 				bool noTransSiblings = transSiblingCount == 0;

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_trans_reduction.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_trans_reduction.cpp
@@ -133,7 +133,7 @@ void TransformationReductionOptimizer::applyOptimOnMesh(
 				std::vector<repo::core::model::RepoNode*> meshVector, metaVector;
 				int transSiblingCount = 0;
 
-				for (auto *child : children)
+				for (auto child : children)
 				{
 					switch (child->getTypeAsEnum())
 					{

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_trans_reduction.h
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_trans_reduction.h
@@ -36,18 +36,6 @@ namespace repo {
 	namespace manipulator {
 		namespace modeloptimizer {
 
-			struct RepoCacheHasher
-			{
-				std::size_t operator()(const RepoCacheTuple &key) const
-				{
-					std::size_t type = std::hash<int>()(static_cast<int>(std::get<0>(key)));
-					std::size_t uuid = repo::lib::RepoUUIDHasher()(static_cast<repo::lib::RepoUUID>(std::get<1>(key)));
-					std::size_t nodeType = std::hash<int>()(static_cast<int>(std::get<2>(key)));
-
-					return nodeType ^ ((type << 2) ^ (type << 1));
-				}
-			};
-
 			class TransformationReductionOptimizer : AbstractOptimizer{
 			public:
 				/**
@@ -69,8 +57,6 @@ namespace repo {
 				* @return returns true upon success
 				*/
 				virtual bool apply(repo::core::model::RepoScene *scene);
-
-				std::unordered_map<RepoCacheTuple, std::vector<repo::core::model::RepoNode *>, RepoCacheHasher> filterCache;
 
 			private:
 				const repo::core::model::RepoScene::GraphType gType;
@@ -95,12 +81,6 @@ namespace repo {
 				void applyOptimOnCamera(
 					repo::core::model::RepoScene *scene,
 					repo::core::model::CameraNode  *camera);
-
-				std::vector<repo::core::model::RepoNode *> getChildrenByIDAndType(
-					repo::core::model::RepoScene *scene,
-					const repo::core::model::RepoScene::GraphType &gType,
-					const repo::lib::RepoUUID  &parent,
-					const repo::core::model::NodeType  &type);
 			};
 		}
 	}

--- a/bouncer/src/repo/repo_controller.h
+++ b/bouncer/src/repo/repo_controller.h
@@ -83,8 +83,8 @@ namespace repo{
 			const int         &port,
 			const std::string &username,
 			const std::string &password,
-			const std::string &bucketName,
-			const std::string &bucketRegion,
+			const std::string &bucketName = "",
+			const std::string &bucketRegion = "",
 			const bool        &pwDigested = false
 			);
 


### PR DESCRIPTION
- Reduced 4 getChildren/getChildrenByType calls to 1 getChildren call and 1 loop to filter for type.
- Removed the whole weird cache thing
-  Ensure meshNodes don't bother with applying transformation if the matrix is an identity
- Removed an iterator in RepoScene in favour of doing it inside an already existing loop