### PR TITLE
Issue 317 - RVT fix

### DIFF
--- a/bouncer/src/repo/core/model/bson/repo_bson.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson.cpp
@@ -101,12 +101,12 @@ RepoBSON RepoBSON::cloneAndShrink() const
 
 repo::lib::RepoUUID RepoBSON::getUUIDField(const std::string &label) const{
 
-	
+
 	if (hasField(label))
 	{
 		const mongo::BSONElement bse = getField(label);
-		return repo::lib::RepoUUID::fromBSONElement(bse);		
-	}	
+		return repo::lib::RepoUUID::fromBSONElement(bse);
+	}
 	else
 	{
 		return repo::lib::RepoUUID::createUUID();
@@ -132,7 +132,7 @@ std::vector<repo::lib::RepoUUID> RepoBSON::getUUIDFieldArray(const std::string &
 		}
 		else
 		{
-			repoError << "getUUIDFieldArray: field " << label << " is an empty bson or wrong type!";
+			repoDebug << "getUUIDFieldArray: field " << label << " is an empty bson or wrong type!";
 		}
 	}
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -274,14 +274,13 @@ void DataProcessorRvt::fillMeshData(const OdGiDrawable* pDrawable)
 	try
 	{
 		collector->setCurrentMeta(fillMetadata(element));
-
 		//some objects material is not set. set default here
 		collector->setCurrentMaterial(GetDefaultMaterial());
-	}
+}	
 	catch(OdError& er)
 	{
 		//.. HOTFIX: handle nullPtr exception (reported to ODA)
-		repoError << "Caught exception whilst: " << convertToStdString(er.description());
+		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
 	}
 
 	std::string layerName = getLevel(element, "Layer Default");
@@ -353,10 +352,42 @@ void DataProcessorRvt::fillMetadataByElemPtr(
 std::pair<std::vector<std::string>, std::vector<std::string>> DataProcessorRvt::fillMetadata(OdBmElementPtr element)
 {
 	std::pair<std::vector<std::string>, std::vector<std::string>> metadata;
-	fillMetadataByElemPtr(element, metadata);
-	fillMetadataById(element->getFamId(), metadata);
-	fillMetadataById(element->getTypeID(), metadata);
-	fillMetadataById(element->getCategroryId(), metadata);
+	try
+	{
+		fillMetadataByElemPtr(element, metadata);
+	}
+	catch (OdError& er)
+	{
+		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
+	}
+
+	try
+	{
+		fillMetadataById(element->getFamId(), metadata);
+	}
+	catch (OdError& er)
+	{
+		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
+	}
+
+	try
+	{
+		fillMetadataById(element->getTypeID(), metadata);
+	}
+	catch (OdError& er)
+	{
+		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
+	}
+
+	try
+	{
+		fillMetadataById(element->getCategroryId(), metadata);
+	}
+	catch (OdError& er)
+	{
+		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
+	}
+
 	return metadata;
 }
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -276,7 +276,7 @@ void DataProcessorRvt::fillMeshData(const OdGiDrawable* pDrawable)
 		collector->setCurrentMeta(fillMetadata(element));
 		//some objects material is not set. set default here
 		collector->setCurrentMaterial(GetDefaultMaterial());
-}	
+	}
 	catch(OdError& er)
 	{
 		//.. HOTFIX: handle nullPtr exception (reported to ODA)

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
@@ -38,7 +38,6 @@
 #include <Main/Entities/BmDirectShapeCell.h>
 #include <Main/Entities/BmDirectShapeDataCell.h>
 
-#include <repo/core/model/bson/repo_bson_builder.h>
 #include <Database/Entities/BmElementHeader.h>
 
 #include <HostObj/Entities/BmLevel.h>
@@ -56,6 +55,7 @@
 #include <Database/Entities/BmGeoLocation.h>
 
 #include "../../../../lib/datastructure/repo_structs.h"
+#include "../../../../core/model/bson/repo_bson_builder.h"
 #include "geometry_collector.h"
 #include "data_processor.h"
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor.h
@@ -17,7 +17,7 @@
 
 #pragma once
 #include "geometry_collector.h"
-#include "repo/error_codes.h"
+#include "../../../../error_codes.h"
 #include <string>
 
 namespace repo {

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
@@ -95,8 +95,10 @@ OdString Get3DLayout(OdDbBaseDatabasePEPtr baseDatabase, OdBmDatabasePtr bimData
 		if (pDBDrawing->getBaseViewNameFormat() == OdBm::ViewType::_3d)
 		{
 			//set first 3D view available
-			if (layoutName.isEmpty())
-				layoutName = pLayout->name(layouts->object());		
+			if (layoutName.isEmpty()) {
+				layoutName = pLayout->name(layouts->object());
+				repoInfo << "First layout name is " << layoutName;
+			}
 
 			//3D View called "3D" has precedence
 			if (pDBDrawing->getName().iCompare("{3D}") == 0) {

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
@@ -97,7 +97,7 @@ OdString Get3DLayout(OdDbBaseDatabasePEPtr baseDatabase, OdBmDatabasePtr bimData
 			//set first 3D view available
 			if (layoutName.isEmpty()) {
 				layoutName = pLayout->name(layouts->object());
-				repoInfo << "First layout name is " << layoutName;
+				repoInfo << "First layout name is " << convertToStdString(pDBDrawing->getName());
 			}
 
 			//3D View called "3D" has precedence

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
@@ -145,8 +145,8 @@ void GeometryCollector::addFace(
 		startMeshEntry();
 	}
 
-	if (faceHasUV && uvCoords.size() == vertices.size()) {
-		repoError << "Vertices size and UV size mismatched!";
+	if (faceHasUV && uvCoords.size() != vertices.size()) {
+		repoError << "Vertices size["<< vertices.size() << "] and UV size ["<< uvCoords.size() <<"] mismatched!";
 		exit(-1);
 	}
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_oda.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_oda.cpp
@@ -1,6 +1,6 @@
 #include "repo_model_import_oda.h"
-#include "repo/core/model/bson/repo_bson_factory.h"
-#include "repo/error_codes.h"
+#include "../../../core/model/bson/repo_bson_factory.h"
+#include "../../../error_codes.h"
 
 #ifdef ODA_SUPPORT
 #include <OdaCommon.h>


### PR DESCRIPTION
- Seg faults were happening due to mismatched lengths of vertices and UVs. This is caused by a condition where we add vertices to the mesh was not adding the UVs
- Also changed some of the includes to be relative paths (the rule is relative if it's within the library, and in `""`, only external libraries should be from root of library path and in `<>`)
- try catch block added within metadata calls to maximise the amount of metadata we'll get.

- According to [this](https://github.com/lerna/lerna/issues/213) using spawn instead of exec should no longer run into `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` problems