### PR TITLE
ISSUE #326 add another property to metadata ignore list.

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -24,6 +24,20 @@
 
 using namespace repo::manipulator::modelconvertor::odaHelper;
 
+//These metadata params are crashing application when we're trying to get them; Report to ODA
+const std::set<std::string> PROBLEMATIC_PARAMS = {
+	"ROOF_SLOPE",
+	"RBS_PIPE_SIZE_MAXIMUM",
+	"RBS_PIPE_SIZE_MINIMUM",
+	"RBS_SYSTEM_CLASSIFICATION_PARAM",
+	"RBS_ELECTRICAL_DATA"
+};
+
+//These metadata params are not of interest to users. Do not read.
+const std::set<std::string> IGNORE_PARAMS = {
+	"RENDER APPEARANCE",
+	"RENDER APPEARANCE PROPERTIES"
+};
 
 bool DataProcessorRvt::ignoreParam(const std::string& param)
 {
@@ -318,7 +332,6 @@ void DataProcessorRvt::fillMetadataByElemPtr(
 	for (OdBuiltInParamArray::iterator it = aParams.begin(); it != aParams.end(); it++)
 	{
 		std::string builtInName = convertToStdString(OdBm::BuiltInParameter(*it).toString());
-
 		//.. HOTFIX: handle access violation exception (reported to ODA)
 		if (ignoreParam(builtInName)) continue;
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
@@ -70,19 +70,6 @@ namespace repo {
 					//Environment variable name for Revit textures
 					const char* RVT_TEXTURES_ENV_VARIABLE = "REPO_RVT_TEXTURES";
 
-					//These metadata params are crashing application when we're trying to get them; Report to ODA
-					const std::set<std::string> PROBLEMATIC_PARAMS = {
-						"ROOF_SLOPE",
-						"RBS_PIPE_SIZE_MAXIMUM",
-						"RBS_PIPE_SIZE_MINIMUM",
-						"RBS_SYSTEM_CLASSIFICATION_PARAM"
-					};
-
-					//These metadata params are crashing application when we're trying to get them; Report to ODA
-					const std::set<std::string> IGNORE_PARAMS = {
-						"RENDER APPEARANCE",
-						"RENDER APPEARANCE PROPERTIES"
-					};
 
 				public:
 					DataProcessorRvt();


### PR DESCRIPTION
this fixes #326 

- Adding another metadata property to the ignore list
- moved the list into the `cpp` instead of `h` to reduce compilation time on modification