### PR TITLE
Issue 332 - RVT meta fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ sandbox/sandbox.cpp
 *.db
 *.opendb
 tools/bouncer_worker/log.log
+*.json

--- a/bouncer/src/repo/core/model/bson/repo_bson_factory.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_factory.h
@@ -237,6 +237,22 @@ namespace repo {
 					const std::vector<repo::lib::RepoUUID> &parents = std::vector<repo::lib::RepoUUID>(),
 					const int                    &apiLevel = REPO_NODE_API_LEVEL_1);
 
+
+				/**
+				* Create a Metadata Node
+				* @param keys labels for the fields
+				* @param values values of the fields, matching the key parameter
+				* @param name Name of Metadata (optional)
+				* @param parents
+				* @param apiLevel Repo Node API level (optional)
+				* @return returns a metadata node
+				*/
+				static MetadataNode makeMetaDataNode(
+					const std::map<std::string, std::string>  &meta,
+					const std::string               &name = std::string(),
+					const std::vector<repo::lib::RepoUUID>     &parents = std::vector<repo::lib::RepoUUID>(),
+					const int                       &apiLevel = REPO_NODE_API_LEVEL_1);
+
 				/**
 				* Create a Metadata Node
 				* @param keys labels for the fields

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -354,7 +354,10 @@ void DataProcessorRvt::fillMetadataByElemPtr(
 				std::string variantValue = translateMetadataValue(value, labelUtils, pDescParam, element->getDatabase(), entry);
 				if (!variantValue.empty())
 				{
-						
+
+					if (metadata.find(metaKey) != metadata.end() && metadata[metaKey] != variantValue) {
+						repoDebug << "FOUND MULTIPLE ENTRY WITH DIFFERENT VALUES: " << metaKey << "value before: " << metadata[metaKey] << " after: " << variantValue;
+					}
 					metadata[metaKey] = variantValue;
 				}
 			}
@@ -365,11 +368,9 @@ void DataProcessorRvt::fillMetadataByElemPtr(
 
 std::map<std::string, std::string> DataProcessorRvt::fillMetadata(OdBmElementPtr element)
 {
-	repoTrace << "============================ START =============================================";
 	std::map<std::string, std::string> metadata;
 	try
 	{
-		repoTrace << "meta 1";
 		fillMetadataByElemPtr(element, metadata);
 	}
 	catch (OdError& er)
@@ -379,7 +380,6 @@ std::map<std::string, std::string> DataProcessorRvt::fillMetadata(OdBmElementPtr
 
 	try
 	{
-		repoTrace << "meta 2";
 		fillMetadataById(element->getFamId(), metadata);
 	}
 	catch (OdError& er)
@@ -389,7 +389,6 @@ std::map<std::string, std::string> DataProcessorRvt::fillMetadata(OdBmElementPtr
 
 	try
 	{
-		repoTrace << "meta 3";
 		fillMetadataById(element->getTypeID(), metadata);
 	}
 	catch (OdError& er)
@@ -399,14 +398,12 @@ std::map<std::string, std::string> DataProcessorRvt::fillMetadata(OdBmElementPtr
 
 	try
 	{
-		repoTrace << "meta 4";
 		fillMetadataById(element->getCategroryId(), metadata);
 	}
 	catch (OdError& er)
 	{
 		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
 	}
-	repoTrace << "============================ END =============================================";
 	return metadata;
 }
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -139,7 +139,11 @@ std::string DataProcessorRvt::translateMetadataValue(
 				}
 				else
 				{
-					strOut = std::to_string((OdUInt64)rawValue.getHandle());
+					OdBmElementPtr elem = database->getObjectId(rawValue.getHandle()).safeOpenObject();
+					if (elem->getElementName() == OdString::kEmpty)
+						strOut = std::to_string((OdUInt64)rawValue.getHandle());
+					else
+						strOut = convertToStdString(elem->getElementName());
 				}
 			}
 	}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
@@ -109,13 +109,13 @@ namespace repo {
 
 					void fillMetadataById(
 						OdBmObjectId id, 
-						std::pair<std::vector<std::string>, std::vector<std::string>>& metadata);
+						std::map<std::string, std::string>& metadata);
 
 					void fillMetadataByElemPtr(
 						OdBmElementPtr element, 
-						std::pair<std::vector<std::string>, std::vector<std::string>>& metadata);
+						std::map<std::string, std::string>& metadata);
 
-					std::pair<std::vector<std::string>, std::vector<std::string>> fillMetadata(OdBmElementPtr element);
+					std::map<std::string, std::string> fillMetadata(OdBmElementPtr element);
 					std::string getLevel(OdBmElementPtr element, const std::string& name);
 					std::string getElementName(OdBmElementPtr element, uint64_t id);
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
@@ -78,7 +78,7 @@ void GeometryCollector::setCurrentMaterial(const repo_material_t &material, bool
 	currMat = checkSum;
 }
 
-void repo::manipulator::modelconvertor::odaHelper::GeometryCollector::setCurrentMeta(const std::pair<std::vector<std::string>, std::vector<std::string>>& meta)
+void repo::manipulator::modelconvertor::odaHelper::GeometryCollector::setCurrentMeta(const std::map<std::string, std::string>& meta)
 {
 	currentMeta = meta;
 }
@@ -288,9 +288,9 @@ repo::core::model::RepoNodeSet GeometryCollector::getMeshNodes(const repo::core:
 
 				auto& metaValues = meshMatEntry.second.metaValues;
 
-				if (!metaValues.first.empty())
+				if (!metaValues.empty())
 				{
-					metaSet.insert(new repo::core::model::MetadataNode(repo::core::model::RepoBSONFactory::makeMetaDataNode(metaValues.first, metaValues.second, meshMatEntry.second.name,
+					metaSet.insert(new repo::core::model::MetadataNode(repo::core::model::RepoBSONFactory::makeMetaDataNode(metaValues, meshMatEntry.second.name,
 					{
 						meshNode.getSharedID()
 					})));

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
@@ -57,7 +57,7 @@ namespace repo {
 					std::string layerName;
 					std::string groupName;
 					uint32_t matIdx;
-					std::pair<std::vector<std::string>, std::vector<std::string>> metaValues;
+					std::map<std::string, std::string> metaValues;
 				};
 
 				class GeometryCollector
@@ -162,7 +162,7 @@ namespace repo {
 					* Change current meta node to the one provided
 					* @param meta node
 					*/
-					void setCurrentMeta(const std::pair<std::vector<std::string>, std::vector<std::string>>& meta);
+					void setCurrentMeta(const std::map<std::string, std::string>& meta);
 
 					/**
 					* Get all meta nodes collected.
@@ -208,7 +208,7 @@ namespace repo {
 					uint32_t currMat;
 					std::vector<double> minMeshBox, origin;
 
-					std::pair<std::vector<std::string>, std::vector<std::string>> currentMeta;
+					std::map<std::string, std::string> currentMeta;
 					repo::core::model::RepoNodeSet metaSet;
 					mesh_data_t *currentEntry = nullptr;
 					bool missingTextures = false;


### PR DESCRIPTION
- Use map instead of pair<vector, vector> to ensure no duplicates
- Read into an param pointer to read the value instead of returning the pointer ID if available.
- after the above, duplicated values seems to have the same data (so far)