### PR TITLE
Issue 344 - fix revit metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
     - sudo make -j2 install
     - export REPO_MODEL_PATH=$PWD/../testData/bouncer/data/models
     - for f in $REPO_MODEL_PATH/*.json; do sed -i.bak -e 's|$REPO_MODEL_PATH|'$REPO_MODEL_PATH'|g' $f; done
-    - LD_LIBRARY_PATH=$OCCT_ROOT/lib/:$IFCOPENSHELL_ROOT/lib:$MONGO_ROOT/lib/:$ASSIMP_ROOT/lib:/usr/local/lib:$ODA_ROOT/bin/lnxX64_5.3dll/:$LD_LIBRARY_PATH 3drepobouncerTest
+    - ODA_CSV_LOCATION=$ODA_ROOT/bin/lnxX64_5.3dll/ LD_LIBRARY_PATH=$OCCT_ROOT/lib/:$IFCOPENSHELL_ROOT/lib:$MONGO_ROOT/lib/:$ASSIMP_ROOT/lib:/usr/local/lib:$ODA_ROOT/bin/lnxX64_5.3dll/:$LD_LIBRARY_PATH 3drepobouncerTest
 after_success:
     - coveralls --root ../ -e "test" -e "submodules" -e "cmake_modules" -e "tools" -e "mongo" -e "assimp" -e "assimp-install" -e "mongo-cxx-1.1.0" -e "aws-install"
 notifications:

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -164,6 +164,7 @@ void DataProcessorRvt::beginViewVectorization()
 {
 	DataProcessor::beginViewVectorization();
 	setEyeToOutputTransform(getEyeToWorldTransform());
+	initLabelUtils();
 }
 
 void DataProcessorRvt::draw(const OdGiDrawable* pDrawable)
@@ -323,6 +324,9 @@ void DataProcessorRvt::initLabelUtils() {
 			repoInfo << "Setting root as: " << env;
 			labelUtils->setLookupRoot(OdString(env));
 		}
+		else {
+			repoWarning << "Cannot find envar ODA_CSV_LOCATION. Metadata may not be processed.";
+		}
 	}
 }
 
@@ -331,9 +335,7 @@ void DataProcessorRvt::fillMetadataByElemPtr(
 	std::unordered_map<std::string, std::string>& metadata)
 {
 	OdBuiltInParamArray aParams;
-	element->getListParams(aParams);
-	
-	initLabelUtils();
+	element->getListParams(aParams);	
 
 	if (!labelUtils) return;
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -284,12 +284,12 @@ void DataProcessorRvt::fillMeshData(const OdGiDrawable* pDrawable)
 	{
 		//some objects material is not set. set default here
 		collector->setCurrentMaterial(GetDefaultMaterial());
-		collector->setMetadata(layerName, fillMetadata(element));			
+		collector->setMetadata(elementName, fillMetadata(element));
 	}
 	catch (OdError& er)
 	{
 		//.. HOTFIX: handle nullPtr exception (reported to ODA)
-		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
+		repoError << "Caught exception whilst: " << convertToStdString(er.description());
 	}
 
 	collector->stopMeshEntry();
@@ -348,7 +348,7 @@ void DataProcessorRvt::fillMetadataByElemPtr(
 				{
 
 					if (metadata.find(metaKey) != metadata.end() && metadata[metaKey] != variantValue) {
-						repoDebug << "FOUND MULTIPLE ENTRY WITH DIFFERENT VALUES: " << metaKey << "value before: " << metadata[metaKey] << " after: " << variantValue;
+						repoError << "FOUND MULTIPLE ENTRY WITH DIFFERENT VALUES: " << metaKey << "value before: " << metadata[metaKey] << " after: " << variantValue;
 					}
 					metadata[metaKey] = variantValue;
 				}
@@ -367,7 +367,7 @@ std::unordered_map<std::string, std::string> DataProcessorRvt::fillMetadata(OdBm
 	}
 	catch (OdError& er)
 	{
-		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
+		repoError << "Caught exception whilst: " << convertToStdString(er.description());
 	}
 
 	try
@@ -376,7 +376,7 @@ std::unordered_map<std::string, std::string> DataProcessorRvt::fillMetadata(OdBm
 	}
 	catch (OdError& er)
 	{
-		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
+		repoError << "Caught exception whilst: " << convertToStdString(er.description());
 	}
 
 	try
@@ -385,7 +385,7 @@ std::unordered_map<std::string, std::string> DataProcessorRvt::fillMetadata(OdBm
 	}
 	catch (OdError& er)
 	{
-		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
+		repoError << "Caught exception whilst: " << convertToStdString(er.description());
 	}
 
 	try
@@ -394,7 +394,7 @@ std::unordered_map<std::string, std::string> DataProcessorRvt::fillMetadata(OdBm
 	}
 	catch (OdError& er)
 	{
-		repoDebug << "Caught exception whilst: " << convertToStdString(er.description());
+		repoError << "Caught exception whilst: " << convertToStdString(er.description());
 	}
 	return metadata;
 }

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -26,6 +26,8 @@
 
 using namespace repo::manipulator::modelconvertor::odaHelper;
 
+static const char* ODA_CSV_LOCATION = "ODA_CSV_LOCATION";
+
 //These metadata params are not of interest to users. Do not read.
 const std::set<std::string> IGNORE_PARAMS = {
 	"RENDER APPEARANCE",
@@ -316,9 +318,11 @@ void DataProcessorRvt::initLabelUtils() {
 	if (!labelUtils) {
 		OdBmLabelUtilsPEPtr _labelUtils = OdBmObject::desc()->getX(OdBmLabelUtilsPE::desc());
 		labelUtils = (OdBmSampleLabelUtilsPE*)_labelUtils.get();
-
-		OdString str("C:\\local\\teigha\\exe\\vc14_amd64dll");
-		labelUtils->setLookupRoot(str);
+		char* env = std::getenv(ODA_CSV_LOCATION);
+		if (env) {
+			repoInfo << "Setting root as: " << env;
+			labelUtils->setLookupRoot(OdString(env));
+		}
 	}
 }
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -22,7 +22,7 @@
 #include "data_processor_rvt.h"
 #include "helper_functions.h"
 #include "../../../../lib/repo_utils.h"
-#include <TB_ExLabelUtils/BmSampleLabelUtilsPE.h>
+
 
 using namespace repo::manipulator::modelconvertor::odaHelper;
 
@@ -312,20 +312,24 @@ void DataProcessorRvt::fillMetadataById(
 	fillMetadataByElemPtr(ptr, metadata);
 }
 
+void DataProcessorRvt::initLabelUtils() {
+	if (!labelUtils) {
+		OdBmLabelUtilsPEPtr _labelUtils = OdBmObject::desc()->getX(OdBmLabelUtilsPE::desc());
+		labelUtils = (OdBmSampleLabelUtilsPE*)_labelUtils.get();
+
+		OdString str("C:\\local\\teigha\\exe\\vc14_amd64dll");
+		labelUtils->setLookupRoot(str);
+	}
+}
+
 void DataProcessorRvt::fillMetadataByElemPtr(
 	OdBmElementPtr element,
 	std::unordered_map<std::string, std::string>& metadata)
 {
 	OdBuiltInParamArray aParams;
 	element->getListParams(aParams);
-
-	OdBmLabelUtilsPEPtr _labelUtils = OdBmObject::desc()->getX(OdBmLabelUtilsPE::desc());
-
-	OdBmSampleLabelUtilsPE* labelUtils = (OdBmSampleLabelUtilsPE*)_labelUtils.get();
-
-	OdString str("C:\\local\\teigha\\exe\\vc14_amd64dll");
-	labelUtils->setLookupRoot(str);
-
+	
+	initLabelUtils();
 
 	if (!labelUtils) return;
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -348,7 +348,7 @@ void DataProcessorRvt::fillMetadataByElemPtr(
 				{
 
 					if (metadata.find(metaKey) != metadata.end() && metadata[metaKey] != variantValue) {
-						repoError << "FOUND MULTIPLE ENTRY WITH DIFFERENT VALUES: " << metaKey << "value before: " << metadata[metaKey] << " after: " << variantValue;
+						repoDebug << "FOUND MULTIPLE ENTRY WITH DIFFERENT VALUES: " << metaKey << "value before: " << metadata[metaKey] << " after: " << variantValue;
 					}
 					metadata[metaKey] = variantValue;
 				}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -22,6 +22,7 @@
 #include "data_processor_rvt.h"
 #include "helper_functions.h"
 #include "../../../../lib/repo_utils.h"
+#include <TB_ExLabelUtils/BmSampleLabelUtilsPE.h>
 
 using namespace repo::manipulator::modelconvertor::odaHelper;
 
@@ -318,9 +319,15 @@ void DataProcessorRvt::fillMetadataByElemPtr(
 	OdBuiltInParamArray aParams;
 	element->getListParams(aParams);
 
-	OdBmLabelUtilsPEPtr labelUtils = OdBmObject::desc()->getX(OdBmLabelUtilsPE::desc());
-	if (labelUtils.isNull())
-		return;
+	OdBmLabelUtilsPEPtr _labelUtils = OdBmObject::desc()->getX(OdBmLabelUtilsPE::desc());
+
+	OdBmSampleLabelUtilsPE* labelUtils = (OdBmSampleLabelUtilsPE*)_labelUtils.get();
+
+	OdString str("C:\\local\\teigha\\exe\\vc14_amd64dll");
+	labelUtils->setLookupRoot(str);
+
+
+	if (!labelUtils) return;
 
 	for (OdBm::BuiltInParameter::Enum entry : aParams) {
 		std::string builtInName = convertToStdString(OdBm::BuiltInParameter(entry).toString());

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
@@ -54,6 +54,8 @@
 #include <Database/Entities/BmBasePoint.h>
 #include <Database/Entities/BmGeoLocation.h>
 
+#include <TB_ExLabelUtils/BmSampleLabelUtilsPE.h>
+
 #include "../../../../lib/datastructure/repo_structs.h"
 #include "../../../../core/model/bson/repo_bson_builder.h"
 #include "geometry_collector.h"
@@ -119,6 +121,8 @@ namespace repo {
 					std::string getLevel(OdBmElementPtr element, const std::string& name);
 					std::string getElementName(OdBmElementPtr element, uint64_t id);
 
+					void initLabelUtils();
+
 					OdBm::DisplayUnitType::Enum getUnits(OdBmDatabasePtr database);
 
 					bool ignoreParam(const std::string& param);
@@ -132,6 +136,7 @@ namespace repo {
 
 					uint64_t meshesCount;
 					OdBmDatabasePtr database;
+					OdBmSampleLabelUtilsPE* labelUtils = nullptr;
 
 				};
 			}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
@@ -280,10 +280,8 @@ repo::core::model::RepoNodeSet GeometryCollector::getMeshNodes(const repo::core:
 				);
 
 
-				repoInfo << "Fetching Meta for " << meshGroupEntry.first;
 				if (idToMeta.find(meshGroupEntry.first) != idToMeta.end()) {
 					metaNodes.insert(createMetaNode(meshGroupEntry.first, { meshNode.getSharedID() }, idToMeta[meshGroupEntry.first]));
-					repoInfo << "Meta Found. metaNodes Count: " << metaNodes.size();
 				}
 
 				if (matToMeshes.find(meshMatEntry.second.matIdx) == matToMeshes.end()) {

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
@@ -80,7 +80,7 @@ void GeometryCollector::setCurrentMaterial(const repo_material_t &material, bool
 
 repo::core::model::RepoNodeSet repo::manipulator::modelconvertor::odaHelper::GeometryCollector::getMetaNodes()
 {
-	return metaSet;
+	return metaNodes;
 }
 
 mesh_data_t GeometryCollector::createMeshEntry() {
@@ -280,8 +280,10 @@ repo::core::model::RepoNodeSet GeometryCollector::getMeshNodes(const repo::core:
 				);
 
 
+				repoInfo << "Fetching Meta for " << meshGroupEntry.first;
 				if (idToMeta.find(meshGroupEntry.first) != idToMeta.end()) {
 					metaNodes.insert(createMetaNode(meshGroupEntry.first, { meshNode.getSharedID() }, idToMeta[meshGroupEntry.first]));
+					repoInfo << "Meta Found. metaNodes Count: " << metaNodes.size();
 				}
 
 				if (matToMeshes.find(meshMatEntry.second.matIdx) == matToMeshes.end()) {

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
@@ -226,7 +226,9 @@ namespace repo {
 					void setMetadata(const std::string &groupName,
 						const std::unordered_map<std::string, std::string> &metaEntry)
 					{
-						idToMeta[groupName] = metaEntry;
+						repoInfo << "Setting meta to  " << groupName << " meta size: " << metaEntry.size();
+						if(metaEntry.size() > 0)
+							idToMeta[groupName] = metaEntry;
 					}
 
 
@@ -242,7 +244,6 @@ namespace repo {
 					uint32_t currMat;
 					std::vector<double> minMeshBox, origin;
 
-					repo::core::model::RepoNodeSet metaSet;
 					mesh_data_t *currentEntry = nullptr;
 					bool missingTextures = false;
 					repo::lib::RepoMatrix rootMatrix;

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
@@ -226,7 +226,6 @@ namespace repo {
 					void setMetadata(const std::string &groupName,
 						const std::unordered_map<std::string, std::string> &metaEntry)
 					{
-						repoInfo << "Setting meta to  " << groupName << " meta size: " << metaEntry.size();
 						if(metaEntry.size() > 0)
 							idToMeta[groupName] = metaEntry;
 					}


### PR DESCRIPTION
The program now takes a env var, `ODA_CSV_LOCATION`, to point to the folder that has the CSV folder (typically ODA's exe folder.)

