### PR TITLE
Issue 393 - Synchro fixes

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
@@ -429,10 +429,10 @@ repo::lib::RepoMatrix64 SynchroModelImport::convertMatrixTo3DRepoWorld(
 	const repo::lib::RepoMatrix64 &matrix,
 	const std::vector<double> &offset) {
 	std::vector<double> toDX = {
-						1, 0, 0, 0,
-						0, 0, -1, 0,
-						0, 1, 0, 0,
-						0, 0, 0,  1
+		1, 0, 0, 0,
+		0, 0, -1, 0,
+		0, 1, 0, 0,
+		0, 0, 0,  1
 	};
 	std::vector<double> toGL = {
 		1, 0, 0, 0,

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
@@ -421,6 +421,9 @@ std::string SynchroModelImport::generateCache(
 	return id;
 }
 
+auto debugId = "da91f68942bedade7a079aac58b29d6";
+uint64_t currentFrameTS = 0;
+
 void SynchroModelImport::updateFrameState(
 	const std::vector<std::shared_ptr<synchro_reader::AnimationTask>> &tasks,
 	std::unordered_map<std::string, std::vector<repo::lib::RepoUUID>> &resourceIDsToSharedIDs,
@@ -468,12 +471,24 @@ void SynchroModelImport::updateFrameState(
 		case synchro_reader::AnimationTask::TaskType::COLOR:
 		{
 			auto colourTask = std::dynamic_pointer_cast<const synchro_reader::ColourTask>(task);
+			if (debugId == colourTask->resourceID) {
+				std::stringstream ss;
+				if (colourTask->color.size()) {
+					for (const auto &colorPart : colourTask->color) {
+						ss << colorPart << ",";
+					}
+				}
+				else {
+					ss << "-RESET-";
+				}
+				repoInfo << "[" << currentFrameTS << "] Color update " << ss.str();
+			}
 			if (resourceIDsToSharedIDs.find(colourTask->resourceID) != resourceIDsToSharedIDs.end()) {
 				auto color = colourTask->color;
 				bool reset = !color.size();
 				auto colour32Bit = reset ? 0 : colourIn32Bit(color);
 				auto meshes = resourceIDsToSharedIDs[colourTask->resourceID];
-				for (const auto mesh : meshes) {
+				for (const auto &mesh : meshes) {
 					meshColourState[mesh].second = reset || meshColourState[mesh].first == colour32Bit ? std::vector<float>() : color;
 				}
 			}
@@ -483,6 +498,9 @@ void SynchroModelImport::updateFrameState(
 		{
 			if (settings.shouldImportAnimations()) {
 				auto transTask = std::dynamic_pointer_cast<const synchro_reader::TransformationTask>(task);
+				if (debugId == transTask->resourceID) {
+					repoInfo << "[" << currentFrameTS << "] Transformation update";
+				}
 				auto meshes = resourceIDsToSharedIDs[transTask->resourceID];
 				transformingResource.insert(transTask->resourceID);
 				if (transTask->reset) {
@@ -534,12 +552,13 @@ void SynchroModelImport::updateFrameState(
 			if (resourceIDsToSharedIDs.find(visibilityTask->resourceID) != resourceIDsToSharedIDs.end()) {
 				auto visibility = visibilityTask->visibility;
 				auto meshes = resourceIDsToSharedIDs[visibilityTask->resourceID];
+				if (debugId == visibilityTask->resourceID) {
+					repoInfo << "[" << currentFrameTS << "] Visiblity update :" << visibility;
+				}
 				for (const auto mesh : meshes) {
+					alphaValueToIDs[meshAlphaState[mesh].second].erase(mesh.toString());
 					if (visibility == -1) {
 						meshAlphaState[mesh].second = meshAlphaState[mesh].first;
-						if (alphaValueToIDs.find(visibility) != alphaValueToIDs.end()) {
-							alphaValueToIDs[visibility].erase(mesh.toString());
-						}
 					}
 					else {
 						meshAlphaState[mesh].second = visibility;
@@ -652,6 +671,11 @@ repo::core::model::RepoScene* SynchroModelImport::generateRepoScene(uint8_t &err
 
 		repoInfo << "Getting tasks... ";
 
+		if (resourceIDsToSharedIDs.find(debugId) != resourceIDsToSharedIDs.end())
+			repoInfo << "resource to shared IDs: " << resourceIDsToSharedIDs[debugId].size();
+		else
+			repoInfo << "resource to shared ID has no entry";
+
 		generateTaskInformation(reader->getTasks(), resourceIDsToSharedIDs, scene);
 
 		repoInfo << "Getting animations... ";
@@ -704,6 +728,7 @@ repo::core::model::RepoScene* SynchroModelImport::generateRepoScene(uint8_t &err
 		int step = total > 10 ? total / 10 : 1;
 		for (const auto &currentFrame : animation.frames) {
 			auto currentTime = currentFrame.first;
+			currentFrameTS = currentTime;
 			updateFrameState(currentFrame.second, resourceIDsToSharedIDs, alphaValueToIDs, meshAlphaState, meshColourState, transformState, clipState, cam, transformingResources, offset);
 			repo::core::model::RepoSequence::FrameData data;
 			data.ref = generateCache(alphaValueToIDs, meshColourState, transformState, clipState, cam, stateBuffers);

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
@@ -387,6 +387,7 @@ std::string SynchroModelImport::generateCache(
 	}
 
 	for (const auto &entry : alphaValueToIDs) {
+		if (!entry.second.size()) continue;
 		repo::lib::PropertyTree transTree;
 		transTree.addToTree(SEQ_CACHE_LABEL_VALUE, entry.first);
 		transTree.addToTree(SEQ_CACHE_LABEL_SHARED_IDS, entry.second);
@@ -538,18 +539,20 @@ void SynchroModelImport::updateFrameState(
 				auto meshes = resourceIDsToSharedIDs[visibilityTask->resourceID];
 
 				for (const auto mesh : meshes) {
-					if (alphaValueToIDs.find(meshAlphaState[mesh].second) != alphaValueToIDs.end())
-						alphaValueToIDs[meshAlphaState[mesh].second].erase(mesh.toString());
+					auto previousState = meshAlphaState[mesh].second;
+					auto meshStr = mesh.toString();
+					if (alphaValueToIDs.find(previousState) != alphaValueToIDs.end())
+						alphaValueToIDs[previousState].erase(meshStr);
 					if (visibility == -1) {
 						meshAlphaState[mesh].second = meshAlphaState[mesh].first;
 					}
 					else {
 						meshAlphaState[mesh].second = visibility;
 						if (alphaValueToIDs.find(visibility) == alphaValueToIDs.end()) {
-							alphaValueToIDs[visibility] = { mesh.toString() };
+							alphaValueToIDs[visibility] = { meshStr };
 						}
 						else {
-							alphaValueToIDs[visibility].insert(mesh.toString());
+							alphaValueToIDs[visibility].insert(meshStr);
 						}
 					}
 				}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
@@ -556,7 +556,8 @@ void SynchroModelImport::updateFrameState(
 					repoInfo << "[" << currentFrameTS << "] Visiblity update :" << visibility;
 				}
 				for (const auto mesh : meshes) {
-					alphaValueToIDs[meshAlphaState[mesh].second].erase(mesh.toString());
+					if (alphaValueToIDs.find(meshAlphaState[mesh].second) != alphaValueToIDs.end())
+						alphaValueToIDs[meshAlphaState[mesh].second].erase(mesh.toString());
 					if (visibility == -1) {
 						meshAlphaState[mesh].second = meshAlphaState[mesh].first;
 					}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.h
@@ -90,6 +90,10 @@ namespace repo {
 				const std::string TASK_END_DATE = "endDate";
 				const std::string TASK_CHILDREN = "subTasks";
 
+				repo::lib::RepoMatrix64 convertMatrixTo3DRepoWorld(
+					const repo::lib::RepoMatrix64 &matrix,
+					const std::vector<double> &offset);
+
 				std::pair<repo::core::model::RepoNodeSet, repo::core::model::RepoNodeSet> generateMatNodes(
 					std::unordered_map<std::string, repo::lib::RepoUUID> &synchroIDtoRepoID,
 					std::unordered_map<repo::lib::RepoUUID, repo::core::model::RepoNode*, repo::lib::RepoUUIDHasher> &repoIDToNode);
@@ -111,7 +115,8 @@ namespace repo {
 					const repo::lib::RepoUUID &parentID);
 
 				repo::core::model::RepoScene* constructScene(
-					std::unordered_map<std::string, std::vector<repo::lib::RepoUUID>> &resourceIDsToSharedIDs);
+					std::unordered_map<std::string, std::vector<repo::lib::RepoUUID>> &resourceIDsToSharedIDs,
+					std::unordered_map<std::string, repo::lib::RepoUUID> &resourceIDsToRootTransID);
 
 				uint32_t colourIn32Bit(const std::vector<float> &color) const;
 
@@ -127,7 +132,8 @@ namespace repo {
 
 				void updateFrameState(
 					const std::vector<std::shared_ptr<synchro_reader::AnimationTask>> &tasks,
-					std::unordered_map<std::string, std::vector<repo::lib::RepoUUID>> &resourceIDsToSharedIDs,
+					const std::unordered_map<std::string, std::vector<repo::lib::RepoUUID>> &resourceIDsToSharedIDs,
+					const std::unordered_map<std::string, repo::lib::RepoMatrix64> &resourceIDLastTrans,
 					std::unordered_map<float, std::set<std::string>> &alphaValueToIDs,
 					std::unordered_map<repo::lib::RepoUUID, std::pair<float, float>, repo::lib::RepoUUIDHasher> &meshAlphaState,
 					std::unordered_map<repo::lib::RepoUUID, std::pair<uint32_t, std::vector<float>>, repo::lib::RepoUUIDHasher> &meshColourState,
@@ -149,7 +155,7 @@ namespace repo {
 					const std::unordered_map<repo::lib::RepoUUID, std::set<SequenceTask, SequenceTaskComparator>, repo::lib::RepoUUIDHasher> &taskToChildren
 				);
 
-				void generateTaskInformation(
+				uint64_t generateTaskInformation(
 					const synchro_reader::TasksInformation &taskInfo,
 					std::unordered_map<std::string, std::vector<repo::lib::RepoUUID>> &resourceIDsToSharedIDs,
 					repo::core::model::RepoScene* &scene


### PR DESCRIPTION
This resolves #393 

- ensure the object is removed from the visibility state cache if the visibility resets/changes
- transformation of the final state is applied and assumed to be the default position. An Inverse of the matrix is applied when the transformation resets.