### PR TITLE
Fixes Issue 406

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/export/repo_model_export_src.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/export/repo_model_export_src.h
@@ -54,6 +54,7 @@ namespace repo{
 
 			private:
 				std::unordered_map<std::string, std::vector<uint8_t>> fullDataBuffer;
+				bool enableCompression;
 
 				/**
 				* Convert a Mesh Node into src format

--- a/bouncer/src/repo/manipulator/modelconvertor/export/repo_model_export_src.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/export/repo_model_export_src.h
@@ -54,7 +54,6 @@ namespace repo{
 
 			private:
 				std::unordered_map<std::string, std::vector<uint8_t>> fullDataBuffer;
-				bool enableCompression;
 
 				/**
 				* Convert a Mesh Node into src format


### PR DESCRIPTION
Compresses the binary buffer section of the SRC file using zlib with Boost stream filters. Indicates this to the application by adjusting the SRC header magic value (as this is no longer a standards compliant SRC).