### PR TITLE
Issue 428 unhandled promise fixes + unity queue improvement

### DIFF
--- a/bouncer/src/repo/lib/repo_log.cpp
+++ b/bouncer/src/repo/lib/repo_log.cpp
@@ -68,7 +68,7 @@ static std::string getTimeAsString()
 	time(&rawtime);
 	timeinfo = localtime(&rawtime);
 
-	strftime(buffer, 80, "%d-%m-%Y_%Hh%Mm%S", timeinfo);
+	strftime(buffer, 80, "%Y-%m-%d_%Hh%Mm%S", timeinfo);
 	return std::string(buffer);
 }
 

--- a/tools/bouncer_worker/README.md
+++ b/tools/bouncer_worker/README.md
@@ -66,8 +66,8 @@ Bouncer worker takes in a JSON file with the following parameters.
     "sharedDir": //Path to the sharedSpace being referenced by the queue
     "maxRetries": //Maximum number of attempts to reconnect to the queue before giving up (default: 3)
     "waitBeforeShutdownMS": //In exitAfter mode, the number of ms to wait before shutting down the application (default: 60000)
-	"pollingIntervalMS" : //In exitAfter mode, the number of ms to wait inbetween polling the queue for tasks (default: 10000)
-	"maxWaitTimeMS" : //In exitAfter mode, the maximum wait time for a task before exiting the process (default: 300000 - aka 5mins)
+    "pollingIntervalMS" : //In exitAfter mode, the number of ms to wait inbetween polling the queue for tasks (default: 10000)
+    "maxWaitTimeMS" : //In exitAfter mode, the maximum wait time for a task before exiting the process (default: 300000 - aka 5mins)
   },
   "bouncer": {
     "path": //path to 3drepobouncerClient

--- a/tools/bouncer_worker/README.md
+++ b/tools/bouncer_worker/README.md
@@ -65,7 +65,9 @@ Bouncer worker takes in a JSON file with the following parameters.
     "model_prefetch": //Number of tasks to process simultaneously on the model queue (default: 1)
     "sharedDir": //Path to the sharedSpace being referenced by the queue
     "maxRetries": //Maximum number of attempts to reconnect to the queue before giving up (default: 3)
-    "waitBeforeShutdownMS": //On runOnceOnQueue mode, the number of ms to wait before shutting down the application (default: 60000)
+    "waitBeforeShutdownMS": //In exitAfter mode, the number of ms to wait before shutting down the application (default: 60000)
+	"pollingIntervalMS" : //In exitAfter mode, the number of ms to wait inbetween polling the queue for tasks (default: 10000)
+	"maxWaitTimeMS" : //In exitAfter mode, the maximum wait time for a task before exiting the process (default: 300000 - aka 5mins)
   },
   "bouncer": {
     "path": //path to 3drepobouncerClient

--- a/tools/bouncer_worker/package.json
+++ b/tools/bouncer_worker/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "amqplib": "0.5.3",
+    "moment": "2.29.1",
     "mongodb": "2.2.24",
     "winston": "3.3.3",
     "yargs": "16.2.0"

--- a/tools/bouncer_worker/src/lib/config.js
+++ b/tools/bouncer_worker/src/lib/config.js
@@ -31,6 +31,8 @@ const applyDefaultValuesIfUndefined = (config) => {
 	config.rabbitmq.task_prefetch = config.rabbitmq.task_prefetch || 4;
 	config.rabbitmq.model_prefetch = config.rabbitmq.model_prefetch || 1;
 	config.rabbitmq.unity_prefetch = config.rabbitmq.unity_prefetch || 1;
+	config.rabbitmq.pollingIntervalMS = config.rabbitmq.pollingIntervalMS || 10 * 1000;
+	config.rabbitmq.maxWaitTimeMS = config.rabbitmq.maxWaitTimeMS || 5 * 60 * 1000;
 	config.rabbitmq.waitBeforeShutdownMS = config.rabbitmq.waitBeforeShutdownMS || 60000;
 
 	// toy project configurations

--- a/tools/bouncer_worker/src/lib/messageDecoder.js
+++ b/tools/bouncer_worker/src/lib/messageDecoder.js
@@ -18,6 +18,7 @@
 const fs = require('fs');
 const { config, configPath } = require('./config');
 const { ERRCODE_ARG_FILE_FAIL } = require('../constants/errorCodes');
+const logger = require('./logger');
 
 const replaceSharedDirPlaceHolder = (command) => {
 	const tagToReplace = '$SHARED_SPACE';
@@ -38,53 +39,58 @@ const messageDecoder = (cmd) => {
 	const args = replaceSharedDirPlaceHolder(cmd).split(/\s+/);
 	let res = { command: args[0] };
 
-	switch (args[0]) {
-		case 'importToy':
-			res = {
-				command: args[0],
-				database: args[1],
-				model: args[2],
-				toyModelID: args[3],
-				skipPostProcessing: (args[4] && JSON.parse(args[4])) || {},
-			};
-			break;
-		case 'import':
-			{
-				// eslint-disable-next-line
-				const cmdFile = require(args[2]);
+	try {
+		switch (args[0]) {
+			case 'importToy':
+				res = {
+					command: args[0],
+					database: args[1],
+					model: args[2],
+					toyModelID: args[3],
+					skipPostProcessing: (args[4] && JSON.parse(args[4])) || {},
+				};
+				break;
+			case 'import':
+				{
+					// eslint-disable-next-line
+					const cmdFile = require(args[2]);
+					res = {
+						cmdParams: [configPath, ...args],
+						database: cmdFile.database,
+						model: cmdFile.project,
+						user: cmdFile.owner,
+						...res,
+					};
+				}
+				break;
+			case 'genFed':
+				{
+					// eslint-disable-next-line
+					const cmdFile = require(args[1]);
+					res = {
+						cmdParams: [configPath, ...args],
+						database: cmdFile.database,
+						model: cmdFile.project,
+						toyFed: cmdFile.toyFed,
+						user: cmdFile.owner,
+						...res,
+					};
+				}
+				break;
+			case 'genStash':
 				res = {
 					cmdParams: [configPath, ...args],
-					database: cmdFile.database,
-					model: cmdFile.project,
-					user: cmdFile.owner,
+					database: args[1],
+					model: args[2],
 					...res,
 				};
-			}
-			break;
-		case 'genFed':
-			{
-				// eslint-disable-next-line
-				const cmdFile = require(args[1]);
-				res = {
-					cmdParams: [configPath, ...args],
-					database: cmdFile.database,
-					model: cmdFile.project,
-					toyFed: cmdFile.toyFed,
-					user: cmdFile.owner,
-					...res,
-				};
-			}
-			break;
-		case 'genStash':
-			res = {
-				cmdParams: [configPath, ...args],
-				database: args[1],
-				model: args[2],
-				...res,
-			};
-			break;
-		default:
-			res = { errorCode: ERRCODE_ARG_FILE_FAIL };
+				break;
+			default:
+				res = { errorCode: ERRCODE_ARG_FILE_FAIL };
+		}
+	} catch (err) {
+		logger.error(`Failed to parse message: ${err.message || err}`);
+		res = { errorCode: ERRCODE_ARG_FILE_FAIL };
 	}
 	return res;
 };

--- a/tools/bouncer_worker/src/lib/messageDecoder.js
+++ b/tools/bouncer_worker/src/lib/messageDecoder.js
@@ -36,10 +36,10 @@ const replaceSharedDirPlaceHolder = (command) => {
 };
 
 const messageDecoder = (cmd) => {
-	const args = replaceSharedDirPlaceHolder(cmd).split(/\s+/);
-	let res = { command: args[0] };
-
+	let res = { };
 	try {
+		const args = replaceSharedDirPlaceHolder(cmd).split(/\s+/);
+		res = { command: args[0] };
 		switch (args[0]) {
 			case 'importToy':
 				res = {

--- a/tools/bouncer_worker/src/lib/queueHandler.js
+++ b/tools/bouncer_worker/src/lib/queueHandler.js
@@ -57,21 +57,21 @@ const establishChannel = async (conn, listenToJobQueue, listenToModelQueue, list
 	const channel = await conn.createChannel();
 	channel.assertQueue(rabbitmq.callback_queue, { durable: true });
 	if (listenToJobQueue) {
-		if (!JobQHandler.validateConfiguration()) {
+		if (!JobQHandler.validateConfiguration(logLabel)) {
 			exitApplication();
 		}
 		listenToQueue(channel, rabbitmq.worker_queue, rabbitmq.task_prefetch, JobQHandler.onMessageReceived);
 	}
 
 	if (listenToModelQueue) {
-		if (!ModelQHandler.validateConfiguration()) {
+		if (!ModelQHandler.validateConfiguration(logLabel)) {
 			exitApplication();
 		}
 		listenToQueue(channel, rabbitmq.model_queue, rabbitmq.model_prefetch, ModelQHandler.onMessageReceived);
 	}
 
 	if (listenToUnityQueue) {
-		if (!UnityQHandler.validateConfiguration()) {
+		if (!UnityQHandler.validateConfiguration(logLabel)) {
 			exitApplication();
 		}
 		listenToQueue(channel, rabbitmq.unity_queue, rabbitmq.unity_prefetch, UnityQHandler.onMessageReceived);
@@ -173,21 +173,21 @@ QueueHandler.runNTasks = async (queueType, nTasks) => {
 	let callback;
 	switch (queueType) {
 		case queueLabel.JOB:
-			if (!JobQHandler.validateConfiguration()) {
+			if (!JobQHandler.validateConfiguration(logLabel)) {
 				exitApplication();
 			}
 			queueName = rabbitmq.worker_queue;
 			callback = JobQHandler.onMessageReceived;
 			break;
 		case queueLabel.MODEL:
-			if (!ModelQHandler.validateConfiguration()) {
+			if (!ModelQHandler.validateConfiguration(logLabel)) {
 				exitApplication();
 			}
 			queueName = rabbitmq.model_queue;
 			callback = ModelQHandler.onMessageReceived;
 			break;
 		case queueLabel.UNITY:
-			if (!UnityQHandler.validateConfiguration()) {
+			if (!UnityQHandler.validateConfiguration(logLabel)) {
 				exitApplication();
 			}
 			queueName = rabbitmq.unity_queue;

--- a/tools/bouncer_worker/src/lib/queueHandler.js
+++ b/tools/bouncer_worker/src/lib/queueHandler.js
@@ -108,7 +108,7 @@ const executeTasks = async (conn, queueName, nTasks, callback) => {
 			break;
 		} else {
 			const waitTime = rabbitmq.pollingIntervalMS;
-			logger.info(`[${tasksCompleted}/${nTasks}] No message found in ${queueName}. Retrying in ${waitTime / 1000}s`, logLabel);
+			logger.verbose(`[${tasksCompleted}/${nTasks}] No message found in ${queueName}. Retrying in ${waitTime / 1000}s`, logLabel);
 
 			// eslint-disable-next-line no-await-in-loop
 			await sleep(waitTime);

--- a/tools/bouncer_worker/src/lib/utils.js
+++ b/tools/bouncer_worker/src/lib/utils.js
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
+const moment = require('moment');
+
 const Utils = {};
 
 Utils.exitApplication = (errCode = -1) => {
@@ -25,5 +27,7 @@ Utils.exitApplication = (errCode = -1) => {
 Utils.sleep = (ms) => new Promise((resolve) => {
 	setTimeout(resolve, ms);
 });
+
+Utils.getCurrentDateTimeAsString = () => moment().format('DD-MM-YY_HH[h]mm[m]ss[s]');
 
 module.exports = Utils;

--- a/tools/bouncer_worker/src/lib/utils.js
+++ b/tools/bouncer_worker/src/lib/utils.js
@@ -28,6 +28,6 @@ Utils.sleep = (ms) => new Promise((resolve) => {
 	setTimeout(resolve, ms);
 });
 
-Utils.getCurrentDateTimeAsString = () => moment().format('DD-MM-YY_HH[h]mm[m]ss[s]');
+Utils.getCurrentDateTimeAsString = () => moment().format('YYYY-MM-DD_HH[h]mm[m]ss[s]');
 
 module.exports = Utils;

--- a/tools/bouncer_worker/src/queues/common.js
+++ b/tools/bouncer_worker/src/queues/common.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2021 3D Repo Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+const fs = require('fs');
+const { config } = require('../lib/config');
+const logger = require('../lib/logger');
+
+const configSpecified = (parent, key, logLabel) => {
+	if (!config[parent] || !config[parent][key]) {
+		logger.error(`${parent}.${key} is not specified!`, logLabel);
+		return false;
+	}
+	return true;
+};
+
+const pathExists = (parent, key, logLabel) => {
+	const filePath = config[parent][key];
+	if (!fs.existsSync(filePath)) {
+		logger.error(`${filePath} (taken from ${parent}.${key}) not found.`, logLabel);
+		return false;
+	}
+	return true;
+};
+
+const queueSpecified = (queue, logLabel) => configSpecified('rabbitmq', queue, logLabel);
+
+const CommonQueueUtils = {};
+
+CommonQueueUtils.callbackQueueSpecified = (logLabel) => queueSpecified('callback_queue', logLabel);
+CommonQueueUtils.jobQueueSpecified = (logLabel) => queueSpecified('worker_queue', logLabel);
+CommonQueueUtils.modelQueueSpecified = (logLabel) => queueSpecified('model_queue', logLabel);
+CommonQueueUtils.unityQueueSpecified = (logLabel) => queueSpecified('unity_queue', logLabel);
+
+CommonQueueUtils.logDirExists = (logLabel) => configSpecified('logging', 'taskLogDir', logLabel)
+											&& pathExists('logging', 'taskLogDir', logLabel);
+CommonQueueUtils.sharedDirExists = (logLabel) => configSpecified('rabbitmq', 'sharedDir', logLabel)
+											&& pathExists('rabbitmq', 'sharedDir', logLabel);
+module.exports = CommonQueueUtils;

--- a/tools/bouncer_worker/src/queues/jobQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/jobQueueHandler.js
@@ -15,6 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
+const {
+	callbackQueueSpecified,
+	jobQueueSpecified,
+	logDirExists,
+	sharedDirExists } = require('./common');
 const { importToyModel, validateToyImporterSettings } = require('../tasks/importToy');
 const { ERRCODE_OK, ERRCODE_TOY_IMPORT_FAILED } = require('../constants/errorCodes');
 const { config } = require('../lib/config');
@@ -84,28 +89,10 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	}
 };
 
-Handler.validateConfiguration = () => {
-	if (!config.logging.taskLogDir) {
-		logger.error('logging.taskLogDir is not specified.', logLabel);
-		return false;
-	}
-
-	if (!config.rabbitmq.worker_queue) {
-		logger.error('rabbitmq.worker_queue is not specified!', logLabel);
-		return false;
-	}
-
-	if (!config.rabbitmq.sharedDir) {
-		logger.error('rabbitmq.sharedDir is not specified!', logLabel);
-		return false;
-	}
-
-	if (!config.rabbitmq.callback_queue) {
-		logger.error('rabbitmq.callback_queue is not specified!', logLabel);
-		return false;
-	}
-
-	return validateToyImporterSettings();
-};
+Handler.validateConfiguration = (label) => logDirExists(label)
+		&& jobQueueSpecified(label)
+		&& sharedDirExists(label)
+		&& callbackQueueSpecified(label)
+		&& validateToyImporterSettings();
 
 module.exports = Handler;

--- a/tools/bouncer_worker/src/queues/jobQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/jobQueueHandler.js
@@ -79,8 +79,11 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	const cmdMsg = messageDecoder(cmd);
 
 	if (cmdMsg.errorCode) {
-		callback({ value: cmdMsg.errorCode });
-	} else if (cmdMsg.command === 'importToy') {
+		callback(JSON.stringify({ value: cmdMsg.errorCode }));
+		return;
+	}
+
+	if (cmdMsg.command === 'importToy') {
 		const message = await importToy(cmdMsg, logDir);
 		callback(JSON.stringify(message));
 	} else {

--- a/tools/bouncer_worker/src/queues/modelQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/modelQueueHandler.js
@@ -36,14 +36,15 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	const { errorCode, database, model, user, cmdParams } = messageDecoder(cmd);
 
 	if (errorCode) {
-		callback({ value: errorCode });
-	} else {
-		callback(JSON.stringify({
-			status: MODEL_PROCESSING,
-			database,
-			project: model,
-		}));
+		callback(JSON.stringify({ value: errorCode }));
+		return;
 	}
+
+	callback(JSON.stringify({
+		status: MODEL_PROCESSING,
+		database,
+		project: model,
+	}));
 
 	const returnMessage = {
 		value: ERRCODE_OK,

--- a/tools/bouncer_worker/src/queues/modelQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/modelQueueHandler.js
@@ -15,6 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
+const {
+	callbackQueueSpecified,
+	modelQueueSpecified,
+	unityQueueSpecified,
+	logDirExists,
+	sharedDirExists } = require('./common');
 const { config } = require('../lib/config');
 const { runBouncerCommand } = require('../tasks/bouncerClient');
 const { ERRCODE_OK, ERRCODE_BOUNCER_CRASH } = require('../constants/errorCodes');
@@ -61,33 +67,10 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	}
 };
 
-Handler.validateConfiguration = () => {
-	if (!config.rabbitmq.model_queue) {
-		logger.error('rabbitmq.model_queue is not specified!', logLabel);
-		return false;
-	}
-
-	if (!config.rabbitmq.callback_queue) {
-		logger.error('rabbitmq.callback_queue is not specified!', logLabel);
-		return false;
-	}
-
-	if (!config.rabbitmq.unity_queue) {
-		logger.error('rabbitmq.unity_queue is not specified!', logLabel);
-		return false;
-	}
-
-	if (!config.rabbitmq.sharedDir) {
-		logger.error('rabbitmq.sharedDir is not specified!', logLabel);
-		return false;
-	}
-
-	if (!config.logging.taskLogDir) {
-		logger.error('logging.taskLogDir is not specified!', logLabel);
-		return false;
-	}
-
-	return true;
-};
+Handler.validateConfiguration = (label) => modelQueueSpecified(label)
+		&& callbackQueueSpecified(label)
+		&& unityQueueSpecified(label)
+		&& logDirExists(label)
+		&& sharedDirExists(label);
 
 module.exports = Handler;

--- a/tools/bouncer_worker/src/queues/unityQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/unityQueueHandler.js
@@ -15,6 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
+const { callbackQueueSpecified, unityQueueSpecified, logDirExists } = require('./common');
 const { config } = require('../lib/config');
 const { generateAssetBundles, validateUnityConfigurations } = require('../tasks/unityEditor');
 const { ERRCODE_ARG_FILE_FAIL, ERRCODE_BUNDLE_GEN_FAIL } = require('../constants/errorCodes');
@@ -61,23 +62,9 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	callback(JSON.stringify(message));
 };
 
-Handler.validateConfiguration = () => {
-	if (!(config.rabbitmq && config.rabbitmq.callback_queue)) {
-		logger.error('rabbitmq.callback_queue is not specified!', logLabel);
-		return false;
-	}
-
-	if (!config.rabbitmq.unity_queue) {
-		logger.error('rabbitmq.unity_queue is not specified!', logLabel);
-		return false;
-	}
-
-	if (!(config.logging && config.logging.taskLogDir)) {
-		logger.error('config.logging.taskLogDir is not specified!', logLabel);
-		return false;
-	}
-
-	return validateUnityConfigurations();
-};
+Handler.validateConfiguration = (label) => callbackQueueSpecified(label)
+		&& unityQueueSpecified(label)
+		&& logDirExists(label)
+		&& validateUnityConfigurations();
 
 module.exports = Handler;

--- a/tools/bouncer_worker/src/tasks/unityEditor.js
+++ b/tools/bouncer_worker/src/tasks/unityEditor.js
@@ -19,6 +19,7 @@ const { config, configPath } = require('../lib/config');
 const { ERRCODE_BUNDLE_GEN_FAIL } = require('../constants/errorCodes');
 const run = require('../lib/runCommand');
 const logger = require('../lib/logger');
+const { getCurrentDateTimeAsString } = require('../lib/utils');
 
 const UnityHandler = {};
 
@@ -26,12 +27,14 @@ const logLabel = { label: 'UNITY' };
 
 UnityHandler.generateAssetBundles = async (database, model, logDir) => {
 	const unityCommand = config.unity.batPath;
+	const dateStr = getCurrentDateTimeAsString();
 	const unityCmdParams = [
 		config.unity.project,
 		configPath,
 		database,
 		model,
-		logDir,
+		`${logDir}/unity_${dateStr}.log`,
+		`${logDir}/run_unity_${dateStr}.log`,
 	];
 
 	try {


### PR DESCRIPTION
This fixes #428
#### Description
- tasks should no longer get stuck in the queue due to instruction file missing
- shared_dir and log_dir are checked at init, process will exit if they do not exist
- Changed unity editor call to depict the full name of unity.log and run_unity.log
- add logic to wait for a task in _exitAfter_ mode if the queue is empty
- introduced 2 new config variables:
    - `pollingIntervalMS` In _exitAfter_ mode, the number of ms to wait inbetween polling the queue for tasks (default: 10000)                                                                                                                                                     
    - `maxWaitTimeMS` In _exitAfter_ mode, the maximum wait time for a task before exiting the process (default: 300000 - aka 5mins)     
