### PR TITLE
ISSUE #433 fix normal groups in sample federation

### DIFF
--- a/tools/bouncer_worker/src/tasks/importToy.js
+++ b/tools/bouncer_worker/src/tasks/importToy.js
@@ -206,14 +206,13 @@ const renameGroups = async (db, database, modelId) => {
 
 	const collection = db.collection(`${modelId}.groups`);
 
-	const setting = db.collection('settings').findOne({ _id: modelId });
+	const setting = await db.collection('settings').findOne({ _id: modelId });
 
 	if (!setting) {
 		throw `Model ${setting} not found`;
 	}
 
 	const oldIdToNewId = {};
-
 	if (setting.subModels) {
 		const subModelList = [];
 		setting.subModels.forEach((subModel) => {


### PR DESCRIPTION
This fixes #433

#### Description
- added missing await keyword on the model settings query. This was the cause for federation not being able to figure out submodel IDs to map to when we import the groups

#### Test cases
- toy federation groups should function like normal

