### PR TITLE
Issue 443 - Pure 2D Lines Model Import Failure

### DIFF
--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
@@ -515,9 +515,29 @@ bool SceneManager::shouldGenerateSrcFiles(
 	const repo::core::model::RepoScene* scene,
 	repo::core::handler::AbstractDatabaseHandler* handler) const
 {
-	repo::core::model::RepoUser user(handler->findOneByCriteria(REPO_ADMIN, REPO_SYSTEM_USERS, BSON("user" << scene->getDatabaseName())));
 	//only generate SRC files if the user has the src flag enabled and there are meshes
-	return scene->getAllMeshes(repo::core::model::RepoScene::GraphType::DEFAULT).size() && user.isSrcEnabled();
+	
+	bool hasTriangleMeshes = false;
+	auto meshes = scene->getAllMeshes(repo::core::model::RepoScene::GraphType::DEFAULT);
+	for (const repo::core::model::RepoNode* node : meshes)
+	{
+		auto mesh = dynamic_cast<const repo::core::model::MeshNode*>(node);
+		if (!mesh)
+		{
+			continue;
+		}
+
+		if (mesh->getPrimitive() == repo::core::model::MeshNode::Primitive::TRIANGLES)
+		{
+			hasTriangleMeshes = true;
+			break;
+		}
+	}
+
+	repo::core::model::RepoUser user(handler->findOneByCriteria(REPO_ADMIN, REPO_SYSTEM_USERS, BSON("user" << scene->getDatabaseName())));
+	bool userHasSrcFlag = user.isSrcEnabled();
+
+	return hasTriangleMeshes && userHasSrcFlag;
 }
 
 bool SceneManager::removeStashGraph(

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
@@ -517,27 +517,26 @@ bool SceneManager::shouldGenerateSrcFiles(
 {
 	//only generate SRC files if the user has the src flag enabled and there are meshes
 	
-	bool hasTriangleMeshes = false;
-	auto meshes = scene->getAllMeshes(repo::core::model::RepoScene::GraphType::DEFAULT);
-	for (const repo::core::model::RepoNode* node : meshes)
+	repo::core::model::RepoUser user(handler->findOneByCriteria(REPO_ADMIN, REPO_SYSTEM_USERS, BSON("user" << scene->getDatabaseName())));
+	if (user.isSrcEnabled())
 	{
-		auto mesh = dynamic_cast<const repo::core::model::MeshNode*>(node);
-		if (!mesh)
+		auto meshes = scene->getAllMeshes(repo::core::model::RepoScene::GraphType::DEFAULT);
+		for (const repo::core::model::RepoNode* node : meshes)
 		{
-			continue;
-		}
+			auto mesh = dynamic_cast<const repo::core::model::MeshNode*>(node);
+			if (!mesh)
+			{
+				continue;
+			}
 
-		if (mesh->getPrimitive() == repo::core::model::MeshNode::Primitive::TRIANGLES)
-		{
-			hasTriangleMeshes = true;
-			break;
+			if (mesh->getPrimitive() == repo::core::model::MeshNode::Primitive::TRIANGLES)
+			{
+				return true; // only need one triangle mesh to warrant generating srcs
+			}
 		}
 	}
 
-	repo::core::model::RepoUser user(handler->findOneByCriteria(REPO_ADMIN, REPO_SYSTEM_USERS, BSON("user" << scene->getDatabaseName())));
-	bool userHasSrcFlag = user.isSrcEnabled();
-
-	return hasTriangleMeshes && userHasSrcFlag;
+	return false;
 }
 
 bool SceneManager::removeStashGraph(


### PR DESCRIPTION
This fixes #443 

`SceneManager::commitScene` decides whether to generate SRCs based on `shouldGenerateSrcFiles`. This method checks for meshes, but does not discriminate primitive type. This PR updates that check to make it explicit.

Note that due to the way the srcAssets.json is generated, models with lines will show errors on loading into Unreal (404s for the missing line supermesh srcs). It is safe to ignore these until they can be fixed properly (by updating, io, bouncer or the plugin).

