### PR TITLE
ISSUE #432 - Vertex Referencing in GeometryCollector

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/CMakeLists.txt
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/CMakeLists.txt
@@ -17,6 +17,7 @@ if(ODA_SUPPORT)
 		${CMAKE_CURRENT_SOURCE_DIR}/geometry_collector.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/helper_functions.cpp
 		${CMAKE_CURRENT_SOURCE_DIR}/vectorise_device_rvt.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/vertex_map.cpp
 		CACHE STRING "SOURCES" FORCE)
 
 	set(HEADERS
@@ -34,6 +35,7 @@ if(ODA_SUPPORT)
 		${CMAKE_CURRENT_SOURCE_DIR}/oda_exsystem_services.h
 		${CMAKE_CURRENT_SOURCE_DIR}/vectorise_device_dgn.h
 		${CMAKE_CURRENT_SOURCE_DIR}/vectorise_device_rvt.h
+		${CMAKE_CURRENT_SOURCE_DIR}/vertex_map.h
 		CACHE STRING "HEADERS" FORCE)
 
 endif()

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
@@ -21,10 +21,12 @@
 #include "../../../../core/model/bson/repo_bson_factory.h"
 #include "../../../../lib/datastructure/repo_structs.h"
 #include "helper_functions.h"
+#include "vertex_map.h"
 
 #include <fstream>
 #include <vector>
 #include <string>
+#include <boost/optional.hpp>
 
 namespace repo {
 	namespace manipulator {
@@ -44,14 +46,9 @@ namespace repo {
 				};
 
 				struct mesh_data_t {
-					std::vector<repo::lib::RepoVector3D64> rawVertices;
-					std::vector<repo::lib::RepoVector3D64> rawNormals;
 					std::vector<repo_face_t> faces;
 					std::vector<std::vector<float>> boundingBox;
-					std::multimap<repo::lib::RepoVector3D64, 
-						std::pair<int, repo::lib::RepoVector3D64>, 
-						RepoVector3D64SortComparator> vToVIndex;
-					std::vector<repo::lib::RepoVector2D> uvCoords;
+					VertexMap vertexMap;
 					std::string name;
 					std::string layerName;
 					std::string groupName;
@@ -264,6 +261,16 @@ namespace repo {
 					int errorCode = REPOERR_OK;
 					repo::lib::RepoMatrix rootMatrix;
 					std::vector<repo::manipulator::modelconvertor::odaHelper::camera_t> cameras;
+
+					/**
+					* Add a face to the current mesh. This method should only be called by one of the overloads above.
+					* Setting a face with uvs but no normals is not supported.
+					*/
+					void addFace(
+						const std::vector<repo::lib::RepoVector3D64>& vertices,
+						boost::optional<const repo::lib::RepoVector3D64&> normal,
+						boost::optional<const std::vector<repo::lib::RepoVector2D>&> uvCoords
+					);
 
 					repo::core::model::TransformationNode* createTransNode(
 						const std::string &name,

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/vertex_map.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/vertex_map.cpp
@@ -1,0 +1,140 @@
+/**
+*  Copyright (C) 2021 3D Repo Ltd
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Affero General Public License as
+*  published by the Free Software Foundation, either version 3 of the
+*  License, or (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Affero General Public License for more details.
+*
+*  You should have received a copy of the GNU Affero General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "vertex_map.h"
+#include <boost/functional/hash.hpp>
+
+using namespace repo::manipulator::modelconvertor::odaHelper;
+
+
+VertexMap::result_t VertexMap::find(const repo::lib::RepoVector3D64& position)
+{
+	size_t hash = 0;
+	boost::hash_combine(hash, position.x);
+	boost::hash_combine(hash, position.y);
+	boost::hash_combine(hash, position.z);
+	
+	auto matching = map.equal_range(hash);
+
+	result_t result;
+
+	for (auto it = matching.first; it != matching.second; it++)
+	{
+		if (vertices[it->second] == position)
+		{
+			result.index = it->second;
+			result.added = false;
+			return result;
+		}
+	}
+
+	auto idx = vertices.size();
+	vertices.push_back(position);
+
+	map.insert(std::pair<size_t, size_t>(hash, idx));
+
+	result.index = idx;
+	result.added = true;	
+
+	return result;
+}
+
+VertexMap::result_t VertexMap::find(const repo::lib::RepoVector3D64& position, const repo::lib::RepoVector3D64& normal)
+{
+	size_t hash = 0;
+	boost::hash_combine(hash, position.x);
+	boost::hash_combine(hash, position.y);
+	boost::hash_combine(hash, position.z);
+	boost::hash_combine(hash, normal.x);
+	boost::hash_combine(hash, normal.y);
+	boost::hash_combine(hash, normal.z);
+
+	auto matching = map.equal_range(hash);
+
+	result_t result;
+
+	for (auto it = matching.first; it != matching.second; it++)
+	{
+		if (vertices[it->second] == position)
+		{
+			if (normals[it->second] == normal) 
+			{
+				result.index = it->second;
+				result.added = false;
+				return result;
+			}
+		}
+	}
+
+	auto idx = vertices.size();
+
+	vertices.push_back(position);
+	normals.push_back(normal);
+
+	map.insert(std::pair<size_t, size_t>(hash, idx));
+
+	result.index = idx;
+	result.added = true;
+
+	return result;
+}
+
+VertexMap::result_t VertexMap::find(const repo::lib::RepoVector3D64& position, const repo::lib::RepoVector3D64& normal, const repo::lib::RepoVector2D& uv)
+{
+	size_t hash = 0;
+	boost::hash_combine(hash, position.x);
+	boost::hash_combine(hash, position.y);
+	boost::hash_combine(hash, position.z);
+	boost::hash_combine(hash, normal.x);
+	boost::hash_combine(hash, normal.y);
+	boost::hash_combine(hash, normal.z);
+	boost::hash_combine(hash, uv.x);
+	boost::hash_combine(hash, uv.y);
+
+	auto matching = map.equal_range(hash);
+
+	result_t result;
+
+	for (auto it = matching.first; it != matching.second; it++)
+	{
+		if (vertices[it->second] == position)
+		{
+			if (normals[it->second] == normal)
+			{
+				if (uvs[it->second] == uv) 
+				{
+					result.index = it->second;
+					result.added = false;
+					return result;
+				}
+			}
+		}
+	}
+
+	auto idx = vertices.size();
+
+	vertices.push_back(position);
+	normals.push_back(normal);
+	uvs.push_back(uv);
+
+	map.insert(std::pair<size_t, size_t>(hash, idx));
+
+	result.index = idx;
+	result.added = true;
+
+	return result;
+}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/vertex_map.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/vertex_map.h
@@ -1,0 +1,59 @@
+/**
+*  Copyright (C) 2021 3D Repo Ltd
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Affero General Public License as
+*  published by the Free Software Foundation, either version 3 of the
+*  License, or (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Affero General Public License for more details.
+*
+*  You should have received a copy of the GNU Affero General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "../../../../error_codes.h"
+#include "../../../../core/model/bson/repo_bson_factory.h"
+#include "../../../../lib/datastructure/repo_structs.h"
+#include "helper_functions.h"
+#include <fstream>
+#include <vector>
+#include <string>
+
+namespace repo {
+	namespace manipulator {
+		namespace modelconvertor {
+			namespace odaHelper {
+
+				/*
+				 * Helper class for referencing existing vertices into indices. This class relies on the format checking in 
+				 * GeometryCollector, and is only for use within mesh_data_t.
+				 */
+				class VertexMap {
+					std::multimap<size_t, size_t> map;
+
+				public:
+					std::vector<repo::lib::RepoVector3D64> vertices;
+					std::vector<repo::lib::RepoVector3D64> normals;
+					std::vector<repo::lib::RepoVector2D> uvs;
+
+					struct result_t
+					{
+						bool added;
+						uint32_t index;
+					};
+
+					result_t find(const repo::lib::RepoVector3D64& position);
+					result_t find(const repo::lib::RepoVector3D64& position, const repo::lib::RepoVector3D64& normal);
+					result_t find(const repo::lib::RepoVector3D64& position, const repo::lib::RepoVector3D64& normal, const repo::lib::RepoVector2D& uv);
+				};
+
+			}
+		}
+	}
+}


### PR DESCRIPTION
This fixes #432. 

When adding faces, the GeometryCollector class attempts to reference existing vertices if possible, before adding new ones, but the previous implementation only considered vertices and an optional normal. This meant texture coordinates may be mismatched, and there was a whole second pathway for lines.

This PR adds a new VertexMap class that performs vertex buffer construction & referencing, updates the GeometryCollector class to use this, and do to so through one addFace overload.