### PR TITLE
Issue 395 get travis to run on focal fossa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,13 @@ matrix:
           - until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done
           - mongo admin testData/bouncer/createUser.js
           - cd  testData/bouncer/data/database/
+          - sudo apt-get install mongo-tools
           - mongorestore -u "testUser" -p "3drepotest" --authenticationDatabase admin --quiet
           - cd ../../../../
           - export CXX="g++"
           - export CC="gcc"
           - gcov --version
           - echo ============ BOOST  INSTALL =============
-            #    - sudo add-apt-repository -y ppa:samuel-bachmann/boost
-            #    - sudo apt-get update
-            #    - sudo apt-get install libboost1.60-all-dev
           - sudo apt-get install libboost-all-dev
           - echo ============ MONGO  INSTALL =============
           - tar -zxf testData/bouncer/ext_libs/focal/mongo-cxx-driver.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ matrix:
           - cd $ODA_ROOT/bin/lnxX64_8.3dll/
           - ODA_CSV_LOCATION=$ODA_ROOT/bin/lnxX64_8.3dll/ PATH=$ODA_ROOT/bin/lnxX64_8.3dll/:$PATH LD_LIBRARY_PATH=$SYNCHRO_READER_ROOT/lib:$THRIFT_ROOT/lib:$OCCT_ROOT/lib/:$IFCOPENSHELL_ROOT/lib:$MONGO_ROOT/lib/:$ASSIMP_ROOT/lib:/usr/local/lib:$ODA_ROOT/bin/lnxX64_8.3dll/:$LD_LIBRARY_PATH:$HOME/bouncer_install/lib ./3drepobouncerTest
       after_success:
+          - pwd
           - cd - && coveralls --root ../ -e "test" -e "submodules" -e "cmake_modules" -e "tools" -e "mongo" -e "assimp" -e "assimp-install" -e "mongo-cxx-1.1.0" -e "aws-install"
 notifications:
     email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@
 matrix:
   include:
     - language: node_js
+      dist: focal
       node_js:
         - "10.15.1"
       script:
         - cd tools/bouncer_worker && yarn install && yarn lint
     - language: cpp
+      dist: focal
       compiler:
            - gcc
 
@@ -38,27 +40,27 @@ matrix:
             #    - sudo apt-get install libboost1.60-all-dev
           - sudo apt-get install libboost-all-dev
           - echo ============ MONGO  INSTALL =============
-          - tar -zxf testData/bouncer/ext_libs/xenial/mongo-cxx-driver.tgz
+          - tar -zxf testData/bouncer/ext_libs/focal/mongo-cxx-driver.tgz
           - export MONGO_ROOT=$PWD/mongo-cxx-driver
           - echo ============ ASSIMP INSTALL =============
-          - tar -zxf testData/bouncer/ext_libs/xenial/assimp.tgz
+          - tar -zxf testData/bouncer/ext_libs/focal/assimp.tgz
           - export ASSIMP_ROOT=$PWD/assimp
           - echo ============ IFCOPENSHELL INSTALL =============
-          - tar -zxf testData/bouncer/ext_libs/xenial/OCCT.tgz
-          - tar -zxf testData/bouncer/ext_libs/xenial/IfcOpenShell.tgz
+          - tar -zxf testData/bouncer/ext_libs/focal/OCCT.tgz
+          - tar -zxf testData/bouncer/ext_libs/focal/IfcOpenShell.tgz
           - sudo apt-get install tk-dev tcl-dev libxmu-dev libxi-dev
           - export OCCT_ROOT=$PWD/OCCT
           - export IFCOPENSHELL_ROOT=$PWD/IfcOpenShell
           - echo ============ TEIGHA INSTALL =============
-          - wget -q $TEIGHA_LIBS_2021_12
+          - wget -q $TEIGHA_FOCAL_LIBS_2021_12
           - tar -zxf teighaLinuxGCC5.3.tgz
           - ls teighaLinuxGCC5.3/Kernel/Include
           - export ODA_ROOT=$PWD/teighaLinuxGCC5.3
-          - export ODA_LIB_DIR=$ODA_ROOT/lib/lnxX64_5.3dll/
+          - export ODA_LIB_DIR=$ODA_ROOT/lib/lnxX64_8.3dll/
           - echo ============ SYNCHRO INSTALL =============
           - sudo apt-get install zlib1g-dev libssl-dev libxft-dev
-          - tar -zxf testData/bouncer/ext_libs/xenial/synchro_6.2/thrift-0.12.0.tgz
-          - tar -zxf testData/bouncer/ext_libs/xenial/3drepoSynchroReader-2.0.0.tgz
+          - tar -zxf testData/bouncer/ext_libs/focal/synchro_6.2/thrift-0.12.0.tgz
+          - tar -zxf testData/bouncer/ext_libs/focal/3drepoSynchroReader-2.0.0.tgz
           - export THRIFT_ROOT=$PWD/thrift-0.12.0
           - export SYNCHRO_READER_ROOT=$PWD/3drepoSynchroReader
           - export SYNCHRO_PLUGIN_LOCATION=$PWD/3drepoSynchroReader/plugins
@@ -76,9 +78,9 @@ matrix:
           - export REPO_MODEL_PATH=$PWD/../testData/bouncer/data/models
           - for f in $REPO_MODEL_PATH/*.json; do sed -i.bak -e 's|$REPO_MODEL_PATH|'$REPO_MODEL_PATH'|g' $f; done
           - cd ~/bouncer_install
-          - cp bin/* $ODA_ROOT/bin/lnxX64_5.3dll/
-          - cd $ODA_ROOT/bin/lnxX64_5.3dll/
-          - ODA_CSV_LOCATION=$ODA_ROOT/bin/lnxX64_5.3dll/ PATH=$ODA_ROOT/bin/lnxX64_5.3dll/:$PATH LD_LIBRARY_PATH=$SYNCHRO_READER_ROOT/lib:$THRIFT_ROOT/lib:$OCCT_ROOT/lib/:$IFCOPENSHELL_ROOT/lib:$MONGO_ROOT/lib/:$ASSIMP_ROOT/lib:/usr/local/lib:$ODA_ROOT/bin/lnxX64_5.3dll/:$LD_LIBRARY_PATH:$HOME/bouncer_install/lib ./3drepobouncerTest
+          - cp bin/* $ODA_ROOT/bin/lnxX64_8.3dll/
+          - cd $ODA_ROOT/bin/lnxX64_8.3dll/
+          - ODA_CSV_LOCATION=$ODA_ROOT/bin/lnxX64_8.3dll/ PATH=$ODA_ROOT/bin/lnxX64_8.3dll/:$PATH LD_LIBRARY_PATH=$SYNCHRO_READER_ROOT/lib:$THRIFT_ROOT/lib:$OCCT_ROOT/lib/:$IFCOPENSHELL_ROOT/lib:$MONGO_ROOT/lib/:$ASSIMP_ROOT/lib:/usr/local/lib:$ODA_ROOT/bin/lnxX64_8.3dll/:$LD_LIBRARY_PATH:$HOME/bouncer_install/lib ./3drepobouncerTest
       after_success:
           - cd - && coveralls --root ../ -e "test" -e "submodules" -e "cmake_modules" -e "tools" -e "mongo" -e "assimp" -e "assimp-install" -e "mongo-cxx-1.1.0" -e "aws-install"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
           - mongodb
       before_script:
           - mkdir build && cd build
-          - cmake -DREPO_BUILD_TOOLS=ON -DREPO_BUILD_CLIENT=ON -DREPO_BUILD_TESTS=ON  -DREPO_BUILD_COVERAGE=ON -DODA_SUPPORT=ON -DCMAKE_CXX_STANDARD=11 -DCMAKE_BUILD_TYPE=Release -DSYNCHRO_SUPPORT=ON -DCMAKE_INSTALL_PREFIX=$HOME/bouncer_install ../
+          - cmake -DREPO_BUILD_TOOLS=ON -DREPO_BUILD_CLIENT=ON -DREPO_BUILD_TESTS=ON  -DREPO_BUILD_COVERAGE=ON -DODA_SUPPORT=ON -DCMAKE_CXX_STANDARD=11 -DCMAKE_BUILD_TYPE=Debug -DSYNCHRO_SUPPORT=ON -DCMAKE_INSTALL_PREFIX=$HOME/bouncer_install ../
           - mongo mydb_test --eval 'db.createUser({user:"testUser",pwd:"3drepotest",roles:["readWrite"]});'
       script:
           - sudo make -j8 install

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
           - export ODA_LIB_DIR=$ODA_ROOT/lib/lnxX64_8.3dll/
           - echo ============ SYNCHRO INSTALL =============
           - sudo apt-get install zlib1g-dev libssl-dev libxft-dev
-          - tar -zxf testData/bouncer/ext_libs/focal/synchro_6.2/thrift-0.12.0.tgz
+          - tar -zxf testData/bouncer/ext_libs/focal/thrift-0.12.0.tgz
           - tar -zxf testData/bouncer/ext_libs/focal/3drepoSynchroReader-2.0.0.tgz
           - export THRIFT_ROOT=$PWD/thrift-0.12.0
           - export SYNCHRO_READER_ROOT=$PWD/3drepoSynchroReader

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ matrix:
           - export IFCOPENSHELL_ROOT=$PWD/IfcOpenShell
           - echo ============ TEIGHA INSTALL =============
           - wget -q $TEIGHA_FOCAL_LIBS_2021_12
-          - tar -zxf teighaLinuxGCC5.3.tgz
-          - ls teighaLinuxGCC5.3/Kernel/Include
-          - export ODA_ROOT=$PWD/teighaLinuxGCC5.3
+          - tar -zxf teighaLinuxGCC8.3.tgz
+          - ls teighaLinuxGCC8.3/Kernel/Include
+          - export ODA_ROOT=$PWD/teighaLinuxGCC8.3
           - export ODA_LIB_DIR=$ODA_ROOT/lib/lnxX64_8.3dll/
           - echo ============ SYNCHRO INSTALL =============
           - sudo apt-get install zlib1g-dev libssl-dev libxft-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ matrix:
           - cd ../../../../
           - export CXX="g++"
           - export CC="gcc"
-          - gcov --version
           - echo ============ BOOST  INSTALL =============
           - sudo apt-get install libboost-all-dev
           - echo ============ MONGO  INSTALL =============


### PR DESCRIPTION
This fixes #395

#### Description
- added new prebuilt libraries to run on focal fossa
- This runs on the default version of GCC/G++ (9.3), boost (1.71), OpenSSL (I forgot exact version... 1.1.* instead of 1.0.2).
- which means I've recompiled every external library with those versions.... yay.

