### PR TITLE
ISSUE #452 detect unity license errors

### DIFF
--- a/bouncer/src/repo/error_codes.h
+++ b/bouncer/src/repo/error_codes.h
@@ -85,3 +85,5 @@
 #define REPOERR_TOY_IMPORT_FAILED 33
 //The scene was read successfully but failed during geometry processing due to content problem
 #define REPOERR_GEOMETRY_ERROR 34
+//Used in bouncer worker only
+#define REPOERR_UNITY_LICENSE_INVALID 35

--- a/tools/bouncer_worker/src/constants/errorCodes.js
+++ b/tools/bouncer_worker/src/constants/errorCodes.js
@@ -24,6 +24,6 @@ module.exports = {
 	ERRCODE_ARG_FILE_FAIL: 16,
 	ERRCODE_TIMEOUT: 29,
 	ERRCODE_TOY_IMPORT_FAILED: 33,
-	BOUNCER_SOFT_FAILS: [7, 10, 15], // failures that should go through to generate bundle
-
+	ERRCODE_UNITY_LICENCE_INVALID: 35,
+	BOUNCER_SOFT_FAILS: [7, 10, 15], // failures that should go through to generate
 };

--- a/tools/bouncer_worker/src/queues/unityQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/unityQueueHandler.js
@@ -18,7 +18,7 @@
 const { callbackQueueSpecified, unityQueueSpecified, logDirExists } = require('./common');
 const { config } = require('../lib/config');
 const { generateAssetBundles, validateUnityConfigurations } = require('../tasks/unityEditor');
-const { ERRCODE_ARG_FILE_FAIL, ERRCODE_BUNDLE_GEN_FAIL } = require('../constants/errorCodes');
+const { ERRCODE_ARG_FILE_FAIL, ERRCODE_UNITY_LICENCE_INVALID } = require('../constants/errorCodes');
 const { UNITY_PROCESSING } = require('../constants/statuses');
 const logger = require('../lib/logger');
 const Utils = require('../lib/utils');
@@ -46,8 +46,12 @@ const processUnity = async (database, model, user, rid, logDir, modelImportErrCo
 			returnMessage.value = ERRCODE_ARG_FILE_FAIL;
 		}
 	} catch (err) {
-		logger.error(`Failed to generate asset bundle: ${err.message || err}`, logLabel);
-		returnMessage.value = ERRCODE_BUNDLE_GEN_FAIL;
+		if (err === ERRCODE_UNITY_LICENCE_INVALID) {
+			logger.error('Failed to generate asset bundle: Invalid unity license', logLabel);
+			throw err;
+		}
+		logger.error(`Failed to generate asset bundle: ${err}`, logLabel);
+		returnMessage.value = err;
 	}
 	return returnMessage;
 };

--- a/tools/bouncer_worker/src/tasks/unityEditor.js
+++ b/tools/bouncer_worker/src/tasks/unityEditor.js
@@ -15,8 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
+const fs = require('fs');
+const readline = require('readline');
 const { config, configPath } = require('../lib/config');
-const { ERRCODE_BUNDLE_GEN_FAIL } = require('../constants/errorCodes');
+const { ERRCODE_BUNDLE_GEN_FAIL, ERRCODE_UNITY_LICENCE_INVALID } = require('../constants/errorCodes');
 const run = require('../lib/runCommand');
 const logger = require('../lib/logger');
 const { getCurrentDateTimeAsString } = require('../lib/utils');
@@ -25,23 +27,55 @@ const UnityHandler = {};
 
 const logLabel = { label: 'UNITY' };
 
+const checkLicenceError = (log) => new Promise((resolve) => {
+	// We want to check if the unity process failed with licensing error.
+	// This seems to fail with an error code on windows, but returns success on linux
+	// So the only way is to look through the log and grep for the error message - super ad hoc!
+	const readStream = fs.createReadStream(log);
+	const rl = readline.createInterface({
+		input: readStream,
+	});
+	let licenseError = false;
+
+	rl.on('line', (line) => {
+		if (
+			line.includes('Current license is invalid and cannot be activated')
+				|| line.includes('Unity has not been activated with a valid License')
+		) {
+			licenseError = true;
+			rl.close();
+		}
+	});
+
+	rl.on('close', () => {
+		resolve(licenseError);
+	});
+});
+
 UnityHandler.generateAssetBundles = async (database, model, rid, logDir, processInformation) => {
 	const unityCommand = config.unity.batPath;
 	const dateStr = getCurrentDateTimeAsString();
+	const unityLog = `${logDir}/unity_${dateStr}.log`;
 	const unityCmdParams = [
 		config.unity.project,
 		configPath,
 		database,
 		model,
 		rid,
-		`${logDir}/unity_${dateStr}.log`,
+		unityLog,
 	];
 
 	try {
-		return await run(unityCommand, unityCmdParams, { logLabel }, processInformation);
+		const retVal = await run(unityCommand, unityCmdParams, { logLabel }, processInformation);
+		if (await checkLicenceError(unityLog)) {
+			throw ERRCODE_UNITY_LICENCE_INVALID;
+		}
+
+		return retVal;
 	} catch (err) {
 		logger.info(`Failed to execute unity command: ${err}`, logLabel);
-		throw ERRCODE_BUNDLE_GEN_FAIL;
+		const invalidLicence = err === ERRCODE_UNITY_LICENCE_INVALID || await checkLicenceError(unityLog);
+		throw invalidLicence ? ERRCODE_UNITY_LICENCE_INVALID : ERRCODE_BUNDLE_GEN_FAIL;
 	}
 };
 


### PR DESCRIPTION
This fixes #452
#### Description
- detect unity license error with a very ad hoc approach (grepping the log)
- if detected, it will override the current retVal and return with a new error code (35).
- This err code is captured on the unity queue handler, if it is true, then it will reject the promise of `onMessageReceived`, which the queue handler will return to the queue with a `nack` - hence it will be put back in the queue for retry.

- This error will be printed on the log as follows: `Failed to generate asset bundle: Invalid unity license`
![image](https://user-images.githubusercontent.com/11945337/126369289-9c16090b-26fb-4e43-9818-62c27003b861.png)



#### Test cases
- normal processes should work as before
- if the box has unity licensing error, it should no longer pretend to succeed and will requeue the message.

