### PR TITLE
ISSUE #480 changes for synchro 6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
           - echo ============ SYNCHRO INSTALL =============
           - sudo apt-get install zlib1g-dev libssl-dev libxft-dev
           - tar -zxf testData/bouncer/ext_libs/focal/thrift-0.12.0.tgz
-          - tar -zxf testData/bouncer/ext_libs/focal/3drepoSynchroReader-2.0.0.tgz
+          - tar -zxf testData/bouncer/ext_libs/focal/3drepoSynchroReader-2.0.1.tgz
           - export THRIFT_ROOT=$PWD/thrift-0.12.0
           - export SYNCHRO_READER_ROOT=$PWD/3drepoSynchroReader
 

--- a/test/src/system/st_3drepobouncerClient.cpp
+++ b/test/src/system/st_3drepobouncerClient.cpp
@@ -391,20 +391,24 @@ TEST(RepoClientTest, UploadTestSPM)
 	ASSERT_TRUE(system(nullptr));
 	std::string db = "stUpload";
 
-	//we support 6.2
-	std::string spmUpload = produceUploadArgs(db, "synchroTest", getDataPath(synchroFile));
+	//commenting out 6.2 as we don't support this right now and it will crash.
+	/*std::string spmUpload = produceUploadArgs(db, "synchroTest", getDataPath(synchroFile));
 	EXPECT_EQ((int)REPOERR_OK, runProcess(spmUpload));
-	EXPECT_TRUE(projectExists(db, "synchroTest"));
+	EXPECT_TRUE(projectExists(db, "synchroTest"));*/
 
-	//we don't support 6.1
-	std::string spmUpload2 = produceUploadArgs(db, "synchroTest2", getDataPath(synchroOldVersion));
+	//we don't support 6.1 - this will currently crash
+	/*std::string spmUpload2 = produceUploadArgs(db, "synchroTest2", getDataPath(synchroOldVersion));
 	EXPECT_EQ((int)REPOERR_UNSUPPORTED_VERSION, runProcess(spmUpload2));
-	EXPECT_FALSE(projectExists(db, "synchroTest2"));
+	EXPECT_FALSE(projectExists(db, "synchroTest2"));*/
 
 	//we also support 6.3
 	std::string spmUpload3 = produceUploadArgs(db, "synchroTest3", getDataPath(synchroVersion6_3));
 	EXPECT_EQ((int)REPOERR_OK, runProcess(spmUpload3));
 	EXPECT_TRUE(projectExists(db, "synchroTest3"));
+
+	std::string spmUpload4 = produceUploadArgs(db, "synchroTest4", getDataPath(synchroVersion6_4));
+	EXPECT_EQ((int)REPOERR_OK, runProcess(spmUpload4));
+	EXPECT_TRUE(projectExists(db, "synchroTest4"));
 }
 
 TEST(RepoClientTest, UploadTestRVTRegressionTests)

--- a/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_synchro.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_synchro.cpp
@@ -36,7 +36,7 @@ TEST(SynchroModelImport, ImportModel)
 {
 	auto import = SynchroModelImport(ModelImportConfig());
 	uint8_t errCode;
-	EXPECT_TRUE(import.importModel(getDataPath(synchroWithTransform), errCode));
+	EXPECT_TRUE(import.importModel(getDataPath(synchroVersion6_4), errCode));
 	EXPECT_EQ(0, errCode);
 
 	auto scene = import.generateRepoScene(errCode);

--- a/test/src/unit/repo_test_database_info.h
+++ b/test/src/unit/repo_test_database_info.h
@@ -57,6 +57,7 @@ const static std::string synchroFile = "synchro.spm";
 const static std::string synchroWithTransform = "withTransformations.spm";
 const static std::string synchroOldVersion = "synchro6_1.spm";
 const static std::string synchroVersion6_3 = "synchro6_3.spm";
+const static std::string synchroVersion6_4 = "synchro6_4.spm";
 
 const static std::string emptyFile = "empty.json";
 const static std::string emptyJSONFile = "empty2.json";


### PR DESCRIPTION
This fixes #480

#### Description
This only contain changes for tests, bulk of the change is in https://github.com/3drepo/SynchroReader/issues/5


#### Test cases
- 6.2 is no longer supported and it will crash
- 6.3 should work as before
- 6.4 should now be supported

