### PR TITLE
Issue 496 - fix killing process after timeout

### DIFF
--- a/tools/bouncer_worker/package.json
+++ b/tools/bouncer_worker/package.json
@@ -20,6 +20,7 @@
     "moment": "2.29.1",
     "mongodb": "3.6.6",
     "systeminformation": "5.6.20",
+    "tree-kill": "1.2.2",
     "winston": "3.3.3",
     "yargs": "16.2.0"
   },

--- a/tools/bouncer_worker/src/lib/runCommand.js
+++ b/tools/bouncer_worker/src/lib/runCommand.js
@@ -41,7 +41,7 @@ const run = (
 	setTimeout(() => {
 		isTimeout = true;
 		if (!hasTerminated) {
-			logger.info('Max processing time reached, terminating the process');
+			logger.info('Max processing time reached, terminating the process', logLabel);
 			kill(cmdExec.pid);
 		}
 	}, timeoutMS);

--- a/tools/bouncer_worker/src/lib/runCommand.js
+++ b/tools/bouncer_worker/src/lib/runCommand.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line security/detect-child-process
 const { spawn } = require('child_process');
+const kill = require('tree-kill');
 const { ERRCODE_TIMEOUT, ERRCODE_UNKNOWN_ERROR } = require('../constants/errorCodes');
 const logger = require('./logger');
 const processMonitor = require('./processMonitor');
@@ -41,10 +42,7 @@ const run = (
 		isTimeout = true;
 		if (!hasTerminated) {
 			logger.info('Max processing time reached, terminating the process');
-			if (!cmdExec.kill()) {
-				logger.info('Could not kill with SIGTERM, using SIGKILL');
-				logger.info('Trying to with SIGKILL, success? ', !!cmdExec.kill('SIGKILL'));
-			}
+			kill(cmdExec.pid);
 		}
 	}, timeoutMS);
 });


### PR DESCRIPTION
This fixes ##496

#### Description
`spawn.kill()` seems to have stopped working on v14. using `tree-kill` instead.

