### PR TITLE
ISSUE #505 couple IFC bug fixes

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_ifc_utils_parser.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_ifc_utils_parser.cpp
@@ -210,7 +210,6 @@ repo::core::model::RepoNodeSet IFCUtilsParser::createTransformationsRecursive(
 					{
 						repoError << "Failed to process child entity " << child->entity->id() << " (" << e.what() << ")" << " element: " << element->entity->id();
 						missingEntities = true;
-						exit(0);
 					}
 				}
 			}
@@ -228,7 +227,6 @@ repo::core::model::RepoNodeSet IFCUtilsParser::createTransformationsRecursive(
 				{
 					repoError << "Failed to process child entity " << child->entity->id() << " (" << e.what() << ")" << " element: " << element->entity->id();
 					missingEntities = true;
-					exit(0);
 				}
 			}
 		}


### PR DESCRIPTION
This fixes #505

#### Description
- rework how `IfcDerivedUnit` is treated, which should support every type of unit we know how to support
- The file in question has an invalid IFC2x3 schema, where `Edition` in `IfcClassification` is omitted. This breaks the whole tree due to how we're catching the error. 2 fixes here:
  - check the argument is not null before we access the value
  - put a try/catch around the part we recurse `childrenElements` (we have it on `extraChildren`, but for some reason it's missing on this one)


#### Test cases
- file in question should now get processed.
NOTE: It still return with missing nodes (which is not investigated and it's possible that it is resolved in #478  ,) but it should no longer fail without geometry.

