### PR TITLE
Issue 524 - replica set connection support

### DIFF
--- a/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
+++ b/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
@@ -74,6 +74,7 @@ MongoDatabaseHandler::MongoDatabaseHandler(
 */
 MongoDatabaseHandler::~MongoDatabaseHandler()
 {
+	mongo::client::shutdown();
 	if (workerPool)
 		delete workerPool;
 }

--- a/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
+++ b/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
@@ -74,9 +74,9 @@ MongoDatabaseHandler::MongoDatabaseHandler(
 */
 MongoDatabaseHandler::~MongoDatabaseHandler()
 {
-	mongo::client::shutdown();
 	if (workerPool)
 		delete workerPool;
+	mongo::client::shutdown();
 }
 
 bool MongoDatabaseHandler::caseInsensitiveStringCompare(

--- a/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
+++ b/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
@@ -96,7 +96,7 @@ uint64_t MongoDatabaseHandler::countItemsInCollection(
 	{
 		errMsg = "Failed to count num. items in collection: database name or collection name was not specified";
 	}
-	try{
+	try {
 		worker = workerPool->getWorker();
 		if (worker)
 			numItems = worker->count(database + "." + collection);
@@ -125,7 +125,7 @@ mongo::BSONObj* MongoDatabaseHandler::createAuthBSON(
 	if (!username.empty() && !database.empty() && !password.empty())
 	{
 		std::string passwordDigest = pwDigested ?
-		password : mongo::DBClientWithCommands::createPasswordDigest(username, password);
+			password : mongo::DBClientWithCommands::createPasswordDigest(username, password);
 		authBson = new mongo::BSONObj(BSON("user" << username <<
 			"db" << database <<
 			"pwd" << passwordDigest <<
@@ -140,7 +140,7 @@ void MongoDatabaseHandler::createCollection(const std::string &database, const s
 	mongo::DBClientBase *worker;
 	if (!(database.empty() || name.empty()))
 	{
-		try{
+		try {
 			worker = workerPool->getWorker();
 			if (worker)
 				worker->createCollection(database + "." + name);
@@ -167,7 +167,7 @@ void MongoDatabaseHandler::createIndex(const std::string &database, const std::s
 	if (!(database.empty() || collection.empty()))
 	{
 		repoInfo << "Creating index for :" << database << "." << collection << " : index: " << obj;
-		try{
+		try {
 			worker = workerPool->getWorker();
 			if (worker)
 				worker->createIndex(database + "." + collection, obj);
@@ -233,7 +233,7 @@ bool MongoDatabaseHandler::dropCollection(
 	mongo::DBClientBase *worker;
 	if (!database.empty() || collection.empty())
 	{
-		try{
+		try {
 			worker = workerPool->getWorker();
 			if (worker)
 				success = worker->dropCollection(database + "." + collection);
@@ -264,7 +264,7 @@ bool MongoDatabaseHandler::dropDatabase(
 	mongo::DBClientBase *worker;
 	if (!database.empty())
 	{
-		try{
+		try {
 			worker = workerPool->getWorker();
 			if (worker)
 				success = worker->dropDatabase(database);
@@ -296,7 +296,7 @@ bool MongoDatabaseHandler::dropDocument(
 	mongo::DBClientBase *worker;
 	if (!database.empty() && !collection.empty())
 	{
-		try{
+		try {
 			worker = workerPool->getWorker();
 			if (success = worker && !bson.isEmpty() && bson.hasField("_id"))
 			{
@@ -334,7 +334,7 @@ bool MongoDatabaseHandler::dropDocuments(
 	mongo::DBClientBase *worker;
 	if (!database.empty() && !collection.empty())
 	{
-		try{
+		try {
 			worker = workerPool->getWorker();
 			if (success = worker && !criteria.isEmpty())
 			{
@@ -365,7 +365,7 @@ bool MongoDatabaseHandler::dropRawFile(
 	const std::string &collection,
 	const std::string &fileName,
 	std::string &errMsg
-	)
+)
 {
 	bool success = true;
 	mongo::DBClientBase *worker;
@@ -382,7 +382,7 @@ bool MongoDatabaseHandler::dropRawFile(
 		return false;
 	}
 
-	try{
+	try {
 		worker = workerPool->getWorker();
 		if (success = worker)
 		{
@@ -434,7 +434,7 @@ std::vector<repo::core::model::RepoBSON> MongoDatabaseHandler::findAllByCriteria
 	if (!criteria.isEmpty())
 	{
 		mongo::DBClientBase *worker;
-		try{
+		try {
 			uint64_t retrieved = 0;
 			std::auto_ptr<mongo::DBClientCursor> cursor;
 			worker = workerPool->getWorker();
@@ -479,7 +479,7 @@ repo::core::model::RepoBSON MongoDatabaseHandler::findOneByCriteria(
 	if (!criteria.isEmpty())
 	{
 		mongo::DBClientBase *worker;
-		try{
+		try {
 			uint64_t retrieved = 0;
 			worker = workerPool->getWorker();
 			if (worker)
@@ -508,7 +508,7 @@ std::vector<repo::core::model::RepoBSON> MongoDatabaseHandler::findAllByUniqueID
 	const std::string& database,
 	const std::string& collection,
 	const repo::core::model::RepoBSON& uuids,
-	const bool ignoreExtFiles){
+	const bool ignoreExtFiles) {
 	std::vector<repo::core::model::RepoBSON> data;
 
 	mongo::BSONArray array = mongo::BSONArray(uuids);
@@ -516,7 +516,7 @@ std::vector<repo::core::model::RepoBSON> MongoDatabaseHandler::findAllByUniqueID
 	if (fieldsCount > 0)
 	{
 		mongo::DBClientBase *worker;
-		try{
+		try {
 			uint64_t retrieved = 0;
 			std::auto_ptr<mongo::DBClientCursor> cursor;
 			worker = workerPool->getWorker();
@@ -544,7 +544,7 @@ std::vector<repo::core::model::RepoBSON> MongoDatabaseHandler::findAllByUniqueID
 				repoError << "Failed to count number of items in collection: cannot obtain a database worker from the pool";
 			}
 
-			if (fieldsCount != retrieved){
+			if (fieldsCount != retrieved) {
 				repoWarning << "Number of documents(" << retrieved << ") retreived by findAllByUniqueIDs did not match the number of unique IDs(" << fieldsCount << ")!";
 			}
 		}
@@ -603,7 +603,7 @@ repo::core::model::RepoBSON MongoDatabaseHandler::findOneBySharedID(
 repo::core::model::RepoBSON  MongoDatabaseHandler::findOneByUniqueID(
 	const std::string& database,
 	const std::string& collection,
-	const repo::lib::RepoUUID& uuid){
+	const repo::lib::RepoUUID& uuid) {
 	repo::core::model::RepoBSON bson;
 	mongo::DBClientBase *worker;
 	try
@@ -633,13 +633,13 @@ repo::core::model::RepoBSON  MongoDatabaseHandler::findOneByUniqueID(
 
 std::vector<repo::core::model::RepoBSON>
 MongoDatabaseHandler::getAllFromCollectionTailable(
-const std::string                             &database,
-const std::string                             &collection,
-const uint64_t                                &skip,
-const uint32_t                                &limit,
-const std::list<std::string>				  &fields,
-const std::string							  &sortField,
-const int									  &sortOrder)
+	const std::string                             &database,
+	const std::string                             &collection,
+	const uint64_t                                &skip,
+	const uint32_t                                &limit,
+	const std::list<std::string>				  &fields,
+	const std::string							  &sortField,
+	const int									  &sortOrder)
 {
 	std::vector<repo::core::model::RepoBSON> bsons;
 	mongo::DBClientBase *worker;
@@ -767,7 +767,7 @@ std::string MongoDatabaseHandler::getProjectFromCollection(const std::string &ns
 	std::string project;
 	//just to make sure string is empty.
 	project.clear();
-	if (ind != std::string::npos){
+	if (ind != std::string::npos) {
 		project = ns.substr(0, ind);
 	}
 	return project;
@@ -796,6 +796,45 @@ std::map<std::string, std::list<std::string> > MongoDatabaseHandler::getDatabase
 
 MongoDatabaseHandler* MongoDatabaseHandler::getHandler(
 	std::string       &errMsg,
+	const std::string &connectionString,
+	const uint32_t    &maxConnections,
+	const std::string &dbName,
+	const std::string &username,
+	const std::string &password,
+	const bool        &pwDigested)
+{
+	if (!handler) {
+		std::string msg;
+		mongo::ConnectionString mongoConnectionString = mongo::ConnectionString::parse(connectionString, msg);
+		if (!msg.empty()) {
+			repoError << "Failed to construct connection string: " << msg;
+			return nullptr;
+		}
+
+		//initialise the mongo client
+		repoTrace << "Handler not present for " << mongoConnectionString.toString() << " instantiating new handler...";
+		try {
+			handler = new MongoDatabaseHandler(mongoConnectionString, maxConnections, dbName, username, password, pwDigested);
+		}
+		catch (mongo::DBException e)
+		{
+			if (handler)
+				delete handler;
+			handler = 0;
+			errMsg = std::string(e.what());
+			repoError << "Error establishing Mongo Handler: " << errMsg;
+		}
+	}
+	else
+	{
+		repoTrace << "Found handler, returning existing handler";
+	}
+
+	return handler;
+}
+
+MongoDatabaseHandler* MongoDatabaseHandler::getHandler(
+	std::string       &errMsg,
 	const std::string &host,
 	const int         &port,
 	const uint32_t    &maxConnections,
@@ -810,10 +849,10 @@ MongoDatabaseHandler* MongoDatabaseHandler::getHandler(
 
 	mongo::ConnectionString mongoConnectionString = mongo::ConnectionString(hostAndPort);
 
-	if (!handler){
+	if (!handler) {
 		//initialise the mongo client
 		repoTrace << "Handler not present for " << mongoConnectionString.toString() << " instantiating new handler...";
-		try{
+		try {
 			handler = new MongoDatabaseHandler(mongoConnectionString, maxConnections, dbName, username, password, pwDigested);
 		}
 		catch (mongo::DBException e)
@@ -847,10 +886,10 @@ MongoDatabaseHandler* MongoDatabaseHandler::getHandler(
 
 	mongo::ConnectionString mongoConnectionString = mongo::ConnectionString(hostAndPort);
 
-	if (!handler){
+	if (!handler) {
 		//initialise the mongo client
 		repoTrace << "Handler not present for " << mongoConnectionString.toString() << " instantiating new handler...";
-		try{
+		try {
 			handler = new MongoDatabaseHandler(mongoConnectionString, maxConnections, dbName, credentials);
 		}
 		catch (mongo::DBException e)
@@ -882,7 +921,7 @@ std::list<std::string> MongoDatabaseHandler::getProjects(const std::string &data
 	// TODO: remove db.info from the list (anything that is not a project basically)
 	std::list<std::string> collections = getCollections(database);
 	std::list<std::string> projects;
-	for (std::list<std::string>::iterator it = collections.begin(); it != collections.end(); ++it){
+	for (std::list<std::string>::iterator it = collections.begin(); it != collections.end(); ++it) {
 		std::string project = getProjectFromCollection(*it, projectExt);
 		if (!project.empty())
 			projects.push_back(project);
@@ -896,12 +935,12 @@ std::vector<uint8_t> MongoDatabaseHandler::getRawFile(
 	const std::string& database,
 	const std::string& collection,
 	const std::string& fname
-	)
+)
 {
 	std::vector<uint8_t> bin;
 
 	mongo::DBClientBase *worker;
-	try{
+	try {
 		worker = workerPool->getWorker();
 		if (worker)
 		{
@@ -958,7 +997,7 @@ bool MongoDatabaseHandler::insertDocument(
 	mongo::DBClientBase *worker;
 	if (!database.empty() || collection.empty())
 	{
-		try{
+		try {
 			worker = workerPool->getWorker();
 			if (worker)
 			{
@@ -992,7 +1031,7 @@ bool MongoDatabaseHandler::insertRawFile(
 	const std::vector<uint8_t> &bin,
 	std::string          &errMsg,
 	const std::string          &contentType
-	)
+)
 {
 	bool success = false;
 	mongo::DBClientBase *worker;
@@ -1020,7 +1059,7 @@ bool MongoDatabaseHandler::insertRawFile(
 	int retry = 0;
 	while (!success && retry < 5)
 	{
-		try{
+		try {
 			worker = workerPool->getWorker();
 			//store the big biary file within GridFS
 			if (worker)
@@ -1067,8 +1106,8 @@ bool MongoDatabaseHandler::performRoleCmd(
 		{
 			errMsg += "Role bson does not contain role name/database name";
 		}
-		else{
-			try{
+		else {
+			try {
 				worker = workerPool->getWorker();
 				if (worker)
 				{
@@ -1138,7 +1177,7 @@ bool MongoDatabaseHandler::performUserCmd(
 
 	if (!user.isEmpty())
 	{
-		try{
+		try {
 			worker = workerPool->getWorker();
 			if (worker)
 			{
@@ -1165,7 +1204,6 @@ bool MongoDatabaseHandler::performUserCmd(
 					repo::core::model::RepoBSON customData = user.getCustomDataBSON();
 					if (!customData.isEmpty())
 						cmdBuilder.append("customData", customData);
-
 
 					//compulsory, so no point checking if it's empty
 					cmdBuilder.appendArray("roles", user.getRolesBSON());
@@ -1213,7 +1251,7 @@ bool MongoDatabaseHandler::upsertDocument(
 	mongo::DBClientBase *worker;
 
 	bool upsert = overwrite;
-	try{
+	try {
 		worker = workerPool->getWorker();
 		if (success = worker)
 		{
@@ -1283,7 +1321,7 @@ bool MongoDatabaseHandler::storeBigFiles(
 	const std::string &collection,
 	const repo::core::model::RepoBSON &obj,
 	std::string &errMsg
-	)
+)
 {
 	bool success = true;
 

--- a/bouncer/src/repo/core/handler/repo_database_handler_mongo.h
+++ b/bouncer/src/repo/core/handler/repo_database_handler_mongo.h
@@ -15,9 +15,9 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- *  Mongo database handler
- */
+ /**
+  *  Mongo database handler
+  */
 
 #pragma once
 
@@ -42,10 +42,10 @@
 #include "../model/bson/repo_bson_user.h"
 #include "../../lib/repo_stack.h"
 
-namespace repo{
-	namespace core{
+namespace repo {
+	namespace core {
 		namespace handler {
-			class MongoDatabaseHandler : public AbstractDatabaseHandler{
+			class MongoDatabaseHandler : public AbstractDatabaseHandler {
 				enum class OPERATION { DROP, INSERT, UPDATE };
 			public:
 				/*
@@ -65,13 +65,13 @@ namespace repo{
 				 *	=============================================================================================
 				 */
 
-				/*
-				 *	=================================== Public Functions ========================================
-				 */
+				 /*
+				  *	=================================== Public Functions ========================================
+				  */
 
-				/**
-				 * A Deconstructor
-				 */
+				  /**
+				   * A Deconstructor
+				   */
 				~MongoDatabaseHandler();
 
 				/**
@@ -79,6 +79,26 @@ namespace repo{
 				* Must call this before trying to reconnect to another database!
 				*/
 				static void disconnectHandler();
+
+				/**
+				 * Returns the instance of MongoDatabaseHandler
+				 * @param errMsg error message if this fails
+				 * @param host hostname of the database
+				 * @param port port number
+				 * @param number of maximum simultaneous connections
+				 * @param username username for authentication
+				 * @param password for authentication
+				 * @param pwDigested true if password is digested
+				 * @return Returns the single instance
+				 */
+				static MongoDatabaseHandler* getHandler(
+					std::string &errMsg,
+					const std::string &connectionString,
+					const uint32_t    &maxConnections = 1,
+					const std::string &dbName = std::string(),
+					const std::string &username = std::string(),
+					const std::string &password = std::string(),
+					const bool        &pwDigested = false);
 
 				/**
 				 * Returns the instance of MongoDatabaseHandler
@@ -179,13 +199,13 @@ namespace repo{
 				*/
 				std::vector<repo::core::model::RepoBSON>
 					getAllFromCollectionTailable(
-					const std::string                             &database,
-					const std::string                             &collection,
-					const uint64_t                                &skip = 0,
-					const uint32_t								  &limit = 0,
-					const std::list<std::string>				  &fields = std::list<std::string>(),
-					const std::string							  &sortField = std::string(),
-					const int									  &sortOrder = -1);
+						const std::string                             &database,
+						const std::string                             &collection,
+						const uint64_t                                &skip = 0,
+						const uint32_t								  &limit = 0,
+						const std::list<std::string>				  &fields = std::list<std::string>(),
+						const std::string							  &sortField = std::string(),
+						const int									  &sortOrder = -1);
 
 				/**
 				* Get a list of all available collections.
@@ -195,14 +215,13 @@ namespace repo{
 				*/
 				std::list<std::string> getCollections(const std::string &database);
 
-
 				/**
 				 * Get a list of all available databases, alphabetically sorted by default.
 				 * @param sort the database
 				 * @return returns a list of database names
 				 */
 				std::list<std::string> getDatabases(const bool &sorted = true);
-			
+
 				/** get the associated projects for the list of database.
 				 * @param list of database
 				 * @return returns a map of database -> list of projects
@@ -261,7 +280,7 @@ namespace repo{
 				* Create an index within the given collection
 				* @param database name of the database
 				* @param name name of the collection
-				* @param index BSONObj specifying the index 
+				* @param index BSONObj specifying the index
 				*/
 				virtual void createIndex(const std::string &database, const std::string &collection, const mongo::BSONObj & obj);
 
@@ -381,7 +400,7 @@ namespace repo{
 					const std::vector<uint8_t> &bin,
 					std::string          &errMsg,
 					const std::string          &contentType = "binary/octet-stream"
-					);
+				);
 
 				/**
 				* Insert a role into the database
@@ -494,7 +513,7 @@ namespace repo{
 					const std::string& collection,
 					const repo::core::model::RepoBSON& criteria,
 					const std::string& sortField = ""
-					);
+				);
 
 				/**
 				*Retrieves the first document matching given Shared ID (SID), sorting is descending
@@ -535,7 +554,7 @@ namespace repo{
 					const std::string& database,
 					const std::string& collection,
 					const std::string& fname
-					);
+				);
 
 				/*
 				 *	=============================================================================================
@@ -570,18 +589,18 @@ namespace repo{
 				 *	=============================================================================================
 				 */
 
-				/*
-				 *	=================================== Private Functions ========================================
-				 */
+				 /*
+				  *	=================================== Private Functions ========================================
+				  */
 
-				/**
-				 * Constructor is private because this class follows the singleton pattern
-				 * @param dbAddress ConnectionString that holds the address to the mongo database
-				 * @param maxConnections max. number of connections to the database
-				 * @param username user name for authentication (optional)
-				 * @param password password of the user (optional)
-				 * @param pwDigested true if pw is digested (optional)
-				 */
+				  /**
+				   * Constructor is private because this class follows the singleton pattern
+				   * @param dbAddress ConnectionString that holds the address to the mongo database
+				   * @param maxConnections max. number of connections to the database
+				   * @param username user name for authentication (optional)
+				   * @param password password of the user (optional)
+				   * @param pwDigested true if pw is digested (optional)
+				   */
 				MongoDatabaseHandler(
 					const mongo::ConnectionString &dbAddress,
 					const uint32_t                &maxConnections,

--- a/bouncer/src/repo/lib/repo_config.cpp
+++ b/bouncer/src/repo/lib/repo_config.cpp
@@ -95,14 +95,17 @@ RepoConfig RepoConfig::fromFile(const std::string &filePath) {
 
 	auto dbAddr = dbTree->get<std::string>("dbhost", "");
 	auto dbPort = dbTree->get<int>("dbport", -1);
+	auto dbConn = dbTree->get<std::string>("connectionString", "");
 	auto username = dbTree->get<std::string>("username", "");
 	auto password = dbTree->get<std::string>("password", "");
 
-	if (dbAddr.empty() || dbPort == -1) {
+	auto useHostAndPort = !dbAddr.empty() && dbPort > 0;
+	if (!useHostAndPort && dbConn.empty()) {
 		throw RepoException("Database address and port not specified within configuration file.");
 	}
 
-	repo::lib::RepoConfig config = { dbAddr, dbPort, username, password };
+	repo::lib::RepoConfig config = useHostAndPort ? RepoConfig(dbAddr, dbPort, username, password) : RepoConfig(dbConn, username, password);
+
 	auto useAsDefault = jsonTree.get<std::string>("defaultStorage", "");
 
 	//Read S3 configurations if found

--- a/bouncer/src/repo/lib/repo_config.cpp
+++ b/bouncer/src/repo/lib/repo_config.cpp
@@ -129,7 +129,8 @@ RepoConfig RepoConfig::fromFile(const std::string &filePath) {
 }
 
 bool RepoConfig::validate() const {
-	const bool dbOk = !dbConf.addr.empty() && (dbConf.username.empty() == dbConf.password.empty()) && dbConf.port > 0;
+	const bool validDBConn = !dbConf.connString.empty() || (!dbConf.addr.empty() && dbConf.port > 0);
+	const bool dbOk = validDBConn && (dbConf.username.empty() == dbConf.password.empty());
 	const bool s3Ok = !s3Conf.configured || (!s3Conf.bucketName.empty() && !s3Conf.bucketRegion.empty());
 	const bool fsOk = !fsConf.configured || (!fsConf.dir.empty() && fsConf.nLevel >= 0);
 

--- a/bouncer/src/repo/lib/repo_config.h
+++ b/bouncer/src/repo/lib/repo_config.h
@@ -20,18 +20,17 @@
 #include "../repo_bouncer_global.h"
 #include "../core/model/bson/repo_bson_ref.h"
 
-
-namespace repo{
-	namespace lib{
+namespace repo {
+	namespace lib {
 		static int REPO_CONFIG_FS_DEFAULT_LEVEL = 2;
 		class RepoConfig
 		{
-
 		public:
 			using FileStorageEngine = repo::core::model::RepoRef::RefType;
 			struct database_config_t {
 				std::string addr;
 				int port = 27017;
+				std::string connString;
 				std::string username;
 				std::string password;
 				bool pwDigested = false;
@@ -48,7 +47,7 @@ namespace repo{
 				int nLevel;
 				bool configured = false;
 			};
-		
+
 			/**
 			* Instantiate Repo Config with a database connection
 			* @params databaseAddr database address
@@ -60,6 +59,19 @@ namespace repo{
 			REPO_API_EXPORT RepoConfig(
 				const std::string &databaseAddr,
 				const int &port,
+				const std::string &username,
+				const std::string &password,
+				const bool pwDigested = false);
+
+			/**
+			* Instantiate Repo Config with a database connection
+			* @params connString connection string
+			* @params username username to login with
+			* @params password password to login with
+			* @param pwDigested true if password given is digested.
+			*/
+			REPO_API_EXPORT RepoConfig(
+				const std::string &connString,
 				const std::string &username,
 				const std::string &password,
 				const bool pwDigested = false);
@@ -93,7 +105,7 @@ namespace repo{
 				const std::string &directory,
 				const int         &level = REPO_CONFIG_FS_DEFAULT_LEVEL,
 				const bool useAsDefault = true
-				);			
+			);
 
 			const database_config_t getDatabaseConfig() const { return dbConf; }
 			const s3_config_t getS3Config() const { return s3Conf; }
@@ -112,7 +124,6 @@ namespace repo{
 			s3_config_t s3Conf;
 			fs_config_t fsConf;
 			FileStorageEngine defaultStorage;
-
 		};
 	}
 }

--- a/bouncer/src/repo/manipulator/repo_manipulator.cpp
+++ b/bouncer/src/repo/manipulator/repo_manipulator.cpp
@@ -71,6 +71,25 @@ bool RepoManipulator::connectAndAuthenticateWithAdmin(
 	return handler != 0;
 }
 
+bool RepoManipulator::connectAndAuthenticateWithAdmin(
+	std::string       &errMsg,
+	const std::string &connString,
+	const uint32_t    &maxConnections,
+	const std::string &username,
+	const std::string &password,
+	const bool        &pwDigested
+)
+{
+	//FIXME: we should have a database manager class that will instantiate new handlers/give existing handlers
+	repo::core::handler::AbstractDatabaseHandler *handler =
+		repo::core::handler::MongoDatabaseHandler::getHandler(
+			errMsg, connString, maxConnections,
+			repo::core::handler::MongoDatabaseHandler::getAdminDatabaseName(),
+			username, password, pwDigested);
+
+	return handler != 0;
+}
+
 repo::core::model::RepoBSON* RepoManipulator::createCredBSON(
 	const std::string &databaseAd,
 	const std::string &username,
@@ -684,7 +703,14 @@ bool RepoManipulator::init(
 ) {
 	auto dbConf = config.getDatabaseConfig();
 	bool success = true;
-	if (success = connectAndAuthenticateWithAdmin(errMsg, dbConf.addr, dbConf.port, nDbConnections, dbConf.username, dbConf.password)) {
+	if (dbConf.connString.empty()) {
+		success = connectAndAuthenticateWithAdmin(errMsg, dbConf.addr, dbConf.port, nDbConnections, dbConf.username, dbConf.password);
+	}
+	else {
+		success = connectAndAuthenticateWithAdmin(errMsg, dbConf.connString, nDbConnections, dbConf.username, dbConf.password);
+	}
+
+	if (success) {
 		repo::core::handler::AbstractDatabaseHandler* handler =
 			repo::core::handler::MongoDatabaseHandler::getHandler(dbConf.addr);
 		success = (bool)repo::core::handler::fileservice::FileManager::instantiateManager(config, handler);

--- a/bouncer/src/repo/manipulator/repo_manipulator.h
+++ b/bouncer/src/repo/manipulator/repo_manipulator.h
@@ -780,6 +780,24 @@ namespace repo {
 				const std::string &password,
 				const bool        &pwDigested = false
 			);
+			/**
+			* Connect to the given database address/port and authenticat the user using Admin database
+			* @param errMsg error message if the function returns false
+			* @param connString connection string to connect to mongo
+			* @param maxConnections maxmimum number of concurrent connections allowed to the database
+			* @param username user name
+			* @param password password of the user
+			* @param pwDigested is the password provided in digested form (default: false)
+			* @return returns true upon success
+			*/
+			bool connectAndAuthenticateWithAdmin(
+				std::string       &errMsg,
+				const std::string &connString,
+				const uint32_t    &maxConnections,
+				const std::string &username,
+				const std::string &password,
+				const bool        &pwDigested = false
+			);
 		};
 	}
 }

--- a/bouncer/src/repo/repo_controller.cpp
+++ b/bouncer/src/repo/repo_controller.cpp
@@ -18,6 +18,7 @@
 #include "repo_controller_internal.cpp.inl" //Inner class implementation
 #include <ctime>
 #include <boost/date_time.hpp>
+#include <repo/core/handler/repo_database_handler_mongo.h>
 #include "lib/repo_exception.h"
 
 using namespace repo;
@@ -44,6 +45,7 @@ RepoController::RepoController(
 RepoController::~RepoController()
 {
 	if (impl) delete impl;
+	repo::core::handler::MongoDatabaseHandler::disconnectHandler();
 }
 
 void RepoController::addAlias(

--- a/bouncer/src/repo/repo_controller_internal.cpp.inl
+++ b/bouncer/src/repo/repo_controller_internal.cpp.inl
@@ -68,7 +68,7 @@ RepoController::RepoToken* RepoController::_RepoControllerImpl::init(
 
 		if (success)
 		{
-			const std::string dbFullAd = dbConf.addr + ":" + std::to_string(dbConf.port);
+			const std::string dbFullAd = dbConf.connString.empty() ? dbConf.addr + ":" + std::to_string(dbConf.port) : dbConf.connString;
 			token = new RepoController::RepoToken(config);
 			repoInfo << "Successfully connected to the " << dbFullAd;
 			if (!dbConf.username.empty())

--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -75,7 +75,7 @@ int32_t knownValid(const std::string &cmd)
 
 int32_t performOperation(
 
-	repo::RepoController *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 )
@@ -149,7 +149,7 @@ int32_t performOperation(
 */
 
 int32_t generateFederation(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 )
@@ -259,7 +259,7 @@ int32_t generateFederation(
 }
 
 bool _generateStash(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const std::string            &type,
 	const std::string            &dbName,
@@ -294,7 +294,7 @@ bool _generateStash(
 }
 
 int32_t generateStash(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 )
@@ -346,7 +346,7 @@ int32_t generateStash(
 }
 
 int32_t getFileFromProject(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 )
@@ -371,7 +371,7 @@ int32_t getFileFromProject(
 }
 
 int32_t importFileAndCommit(
-	repo::RepoController *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 )

--- a/client/src/functions.h
+++ b/client/src/functions.h
@@ -61,7 +61,7 @@ int32_t knownValid(const std::string &cmd);
 * @return returns true upon success
 */
 int32_t performOperation(
-	repo::RepoController *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 	);
@@ -79,7 +79,7 @@ int32_t performOperation(
 * @return returns true upon success
 */
 int32_t generateFederation(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 	);
@@ -92,7 +92,7 @@ int32_t generateFederation(
 * @return returns true upon success
 */
 static int32_t generateStash(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 	);
@@ -105,7 +105,7 @@ static int32_t generateStash(
 * @return returns true upon success
 */
 static int32_t getFileFromProject(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 	);
@@ -118,7 +118,7 @@ static int32_t getFileFromProject(
 * @return returns true upon success
 */
 static int32_t importFileAndCommit(
-	repo::RepoController *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 	);

--- a/tools/admin/functions.cpp
+++ b/tools/admin/functions.cpp
@@ -74,7 +74,7 @@ int32_t knownValid(const std::string &cmd)
 
 int32_t performOperation(
 
-	repo::RepoController *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 )
@@ -123,22 +123,22 @@ int32_t performOperation(
 * ======================== Command helper functions ===================
 */
 
-static bool genRepoStash(repo::RepoController *controller, const repo::RepoController::RepoToken *token, repo::core::model::RepoScene *scene)
+static bool genRepoStash(std::shared_ptr<repo::RepoController> controller, const repo::RepoController::RepoToken *token, repo::core::model::RepoScene *scene)
 {
 	return controller->generateAndCommitStashGraph(token, scene);
 }
 
-static bool genSrcStash(repo::RepoController *controller, const repo::RepoController::RepoToken *token, repo::core::model::RepoScene *scene)
+static bool genSrcStash(std::shared_ptr<repo::RepoController> controller, const repo::RepoController::RepoToken *token, repo::core::model::RepoScene *scene)
 {
 	return controller->generateAndCommitSRCBuffer(token, scene);
 }
 
-static bool genGLTFStash(repo::RepoController *controller, const repo::RepoController::RepoToken *token, repo::core::model::RepoScene *scene)
+static bool genGLTFStash(std::shared_ptr<repo::RepoController> controller, const repo::RepoController::RepoToken *token, repo::core::model::RepoScene *scene)
 {
 	return controller->generateAndCommitGLTFBuffer(token, scene);
 }
 
-static bool genSelectionTree(repo::RepoController *controller, const repo::RepoController::RepoToken *token, repo::core::model::RepoScene *scene)
+static bool genSelectionTree(std::shared_ptr<repo::RepoController> controller, const repo::RepoController::RepoToken *token, repo::core::model::RepoScene *scene)
 {
 	return controller->generateAndCommitSelectionTree(token, scene);
 }
@@ -172,7 +172,7 @@ static std::list<std::string> readListFromFile(const std::string &fileLoc)
 */
 
 int32_t generateStash(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 )
@@ -217,7 +217,7 @@ int32_t generateStash(
 		return REPOERR_INVALID_ARG;
 	}
 
-	std::function<bool(repo::RepoController*, const repo::RepoController::RepoToken*, repo::core::model::RepoScene*)> genFn;
+	std::function<bool(std::shared_ptr<repo::RepoController> , const repo::RepoController::RepoToken*, repo::core::model::RepoScene*)> genFn;
 	bool stashOnly = false;
 
 	if (type == "repo")
@@ -301,7 +301,7 @@ int32_t generateStash(
 }
 
 int32_t runImport(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo_op_t            &command
 )
 {

--- a/tools/admin/functions.h
+++ b/tools/admin/functions.h
@@ -66,7 +66,7 @@ int32_t knownValid(const std::string &cmd);
 * @return returns true upon success
 */
 int32_t performOperation(
-	repo::RepoController *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 );
@@ -83,12 +83,12 @@ int32_t performOperation(
 * @return returns true upon success
 */
 static int32_t generateStash(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo::RepoController::RepoToken      *token,
 	const repo_op_t            &command
 );
 
 static int32_t runImport(
-	repo::RepoController       *controller,
+	std::shared_ptr<repo::RepoController> controller,
 	const repo_op_t            &command
 );


### PR DESCRIPTION
This fixes #524

#### Description
- Add an option to read database info from a connection string


#### Test cases
- old configurations should still work as before
- replacing `dbHost` and `dbPort` with `connectionString` should also work

