### PR TITLE
ISSUE #531 fix replicaSet connection when processing models through bouncerwrapper

### DIFF
--- a/bouncer/src/repo/repo_controller.cpp
+++ b/bouncer/src/repo/repo_controller.cpp
@@ -44,8 +44,11 @@ RepoController::RepoController(
 
 RepoController::~RepoController()
 {
+	repoInfo << "Destorying impl";
 	if (impl) delete impl;
+	repoInfo << "disconnecting handler";
 	repo::core::handler::MongoDatabaseHandler::disconnectHandler();
+	repoInfo << "done.";
 }
 
 void RepoController::addAlias(

--- a/bouncer/src/repo/repo_controller.cpp
+++ b/bouncer/src/repo/repo_controller.cpp
@@ -44,11 +44,8 @@ RepoController::RepoController(
 
 RepoController::~RepoController()
 {
-	repoInfo << "Destorying impl";
 	if (impl) delete impl;
-	repoInfo << "disconnecting handler";
 	repo::core::handler::MongoDatabaseHandler::disconnectHandler();
-	repoInfo << "done.";
 }
 
 void RepoController::addAlias(

--- a/wrapper/src/c_sharp_wrapper.cpp
+++ b/wrapper/src/c_sharp_wrapper.cpp
@@ -37,6 +37,7 @@ CSharpWrapper::CSharpWrapper()
 
 CSharpWrapper::~CSharpWrapper()
 {
+	repoInfo << "@wrapper deconstructor";
 	if (controller)
 	{
 		repoInfo << "Controller around, destroying token";

--- a/wrapper/src/c_sharp_wrapper.cpp
+++ b/wrapper/src/c_sharp_wrapper.cpp
@@ -37,19 +37,14 @@ CSharpWrapper::CSharpWrapper()
 
 CSharpWrapper::~CSharpWrapper()
 {
-	repoInfo << "@wrapper deconstructor";
 	if (controller)
 	{
-		repoInfo << "Controller around, destroying token";
 		if (token)
 			controller->destroyToken(token);
-		repoInfo << "Destroying scene...";
 		if (scene)
 			delete scene;
-		repoInfo << "Destroying controller..";
 		delete controller;
 
-		repoInfo << "done";
 	}
 
 }

--- a/wrapper/src/c_sharp_wrapper.cpp
+++ b/wrapper/src/c_sharp_wrapper.cpp
@@ -39,7 +39,6 @@ CSharpWrapper::~CSharpWrapper()
 {
 	if (controller)
 	{
-		repoInfo << "Deconstructing the controller.";
 		if (token)
 			controller->destroyToken(token);
 		if (scene)

--- a/wrapper/src/c_sharp_wrapper.cpp
+++ b/wrapper/src/c_sharp_wrapper.cpp
@@ -25,7 +25,7 @@
 
 using namespace repo::lib;
 
-std::shared_ptr<CSharpWrapper> CSharpWrapper::wrapper = nullptr;
+CSharpWrapper* CSharpWrapper::wrapper = nullptr;
 
 CSharpWrapper::CSharpWrapper()
 	: controller(new repo::RepoController()),
@@ -88,12 +88,18 @@ void CSharpWrapper::getIdMapBuffer(
 	}
 }
 
-std::shared_ptr<CSharpWrapper> CSharpWrapper::getInstance()
+CSharpWrapper* CSharpWrapper::getInstance()
 {
 	if (!wrapper) {
-		wrapper = std::shared_ptr<CSharpWrapper>(new CSharpWrapper());
+		wrapper = new CSharpWrapper();
 	}
 	return wrapper;
+}
+
+void CSharpWrapper::destroyInstance() {
+	if(wrapper) {
+		delete wrapper;
+	}
 }
 
 void CSharpWrapper::getMaterialInfo(

--- a/wrapper/src/c_sharp_wrapper.cpp
+++ b/wrapper/src/c_sharp_wrapper.cpp
@@ -25,7 +25,8 @@
 
 using namespace repo::lib;
 
-CSharpWrapper* CSharpWrapper::wrapper = nullptr;
+std::shared_ptr<CSharpWrapper> CSharpWrapper::wrapper = nullptr;
+
 CSharpWrapper::CSharpWrapper()
 	: controller(new repo::RepoController()),
 	token(nullptr),
@@ -81,10 +82,11 @@ void CSharpWrapper::getIdMapBuffer(
 	}
 }
 
-CSharpWrapper* CSharpWrapper::getInstance()
+std::shared_ptr<CSharpWrapper> CSharpWrapper::getInstance()
 {
-	if (!wrapper)
-		wrapper = new CSharpWrapper();
+	if (!wrapper) {
+		wrapper = std::shared_ptr<CSharpWrapper>(new CSharpWrapper());
+	}
 	return wrapper;
 }
 

--- a/wrapper/src/c_sharp_wrapper.cpp
+++ b/wrapper/src/c_sharp_wrapper.cpp
@@ -39,6 +39,7 @@ CSharpWrapper::~CSharpWrapper()
 {
 	if (controller)
 	{
+		repoInfo << "Deconstructing the controller.";
 		if (token)
 			controller->destroyToken(token);
 		if (scene)

--- a/wrapper/src/c_sharp_wrapper.cpp
+++ b/wrapper/src/c_sharp_wrapper.cpp
@@ -39,11 +39,16 @@ CSharpWrapper::~CSharpWrapper()
 {
 	if (controller)
 	{
+		repoInfo << "Controller around, destroying token";
 		if (token)
 			controller->destroyToken(token);
+		repoInfo << "Destroying scene...";
 		if (scene)
 			delete scene;
+		repoInfo << "Destroying controller..";
 		delete controller;
+
+		repoInfo << "done";
 	}
 
 }

--- a/wrapper/src/c_sharp_wrapper.h
+++ b/wrapper/src/c_sharp_wrapper.h
@@ -29,7 +29,9 @@ namespace repo{
 			/**
 			* Singleton class - get its instance
 			*/
-			static std::shared_ptr<CSharpWrapper> getInstance();
+			static CSharpWrapper* getInstance();
+			
+			static void destroyInstance();
 
 			/**
 			* Connect to a mongo database, authenticate by the admin database
@@ -219,7 +221,7 @@ namespace repo{
 				int      length
 				);
 
-			static std::shared_ptr<CSharpWrapper> wrapper;
+			static CSharpWrapper* wrapper;
 		private:
 			CSharpWrapper();
 			repo::RepoController* controller;

--- a/wrapper/src/c_sharp_wrapper.h
+++ b/wrapper/src/c_sharp_wrapper.h
@@ -29,7 +29,7 @@ namespace repo{
 			/**
 			* Singleton class - get its instance
 			*/
-			static CSharpWrapper* getInstance();
+			static std::shared_ptr<CSharpWrapper> getInstance();
 
 			/**
 			* Connect to a mongo database, authenticate by the admin database
@@ -219,7 +219,7 @@ namespace repo{
 				int      length
 				);
 
-			static CSharpWrapper* wrapper;
+			static std::shared_ptr<CSharpWrapper> wrapper;
 		private:
 			CSharpWrapper();
 			repo::RepoController* controller;

--- a/wrapper/src/repo_csharp_interface.cpp
+++ b/wrapper/src/repo_csharp_interface.cpp
@@ -176,3 +176,7 @@ bool repoSaveAssetBundles(
 	auto wrapper = repo::lib::CSharpWrapper::getInstance();
 	return wrapper->saveAssetBundles(assetFiles, length);
 }
+
+void repoDeinit() {
+	repo::lib::CSharpWrapper::destroyInstance();
+}

--- a/wrapper/src/repo_csharp_interface.h
+++ b/wrapper/src/repo_csharp_interface.h
@@ -218,4 +218,10 @@ extern "C"
 		char** assetFiles,
 		int      length
 	);
+	
+	/**
+	* Deinitialisation. Call this function when you are done so
+	* the library can clean itself up properly.
+	*/
+	REPO_WRAPPER_API_EXPORT void repoDeinit();
 }

--- a/wrapper_test/src/unit/ut_repo_csharp_interface.cpp
+++ b/wrapper_test/src/unit/ut_repo_csharp_interface.cpp
@@ -64,7 +64,6 @@ TEST(RepoCsharpInterface, LoadScene)
 		&database[0],
 		&project[0]);
 	ASSERT_FALSE(isFederation);
-	repoDeinit();
 }
 
 TEST(RepoCsharpInterface, AssetBundleSave)
@@ -90,5 +89,4 @@ TEST(RepoCsharpInterface, AssetBundleSave)
 	char* dummyAssetBundlePathPtr = &dummyAssetBundlePath[0];
 	bool assetsSavedCorrectly = repoSaveAssetBundles(&dummyAssetBundlePathPtr, 1);
 	ASSERT_TRUE(assetsSavedCorrectly);
-	repoDeinit();
 }

--- a/wrapper_test/src/unit/ut_repo_csharp_interface.cpp
+++ b/wrapper_test/src/unit/ut_repo_csharp_interface.cpp
@@ -64,6 +64,7 @@ TEST(RepoCsharpInterface, LoadScene)
 		&database[0],
 		&project[0]);
 	ASSERT_FALSE(isFederation);
+	repoDeinit();
 }
 
 TEST(RepoCsharpInterface, AssetBundleSave)
@@ -89,4 +90,5 @@ TEST(RepoCsharpInterface, AssetBundleSave)
 	char* dummyAssetBundlePathPtr = &dummyAssetBundlePath[0];
 	bool assetsSavedCorrectly = repoSaveAssetBundles(&dummyAssetBundlePathPtr, 1);
 	ASSERT_TRUE(assetsSavedCorrectly);
+	repoDeinit();
 }


### PR DESCRIPTION

This fixes #532

#### Description
- changed raw pointer to shared_ptr so it will call the deconstructor prior to exiting


#### Test cases
- replicaset connection should no longer time out

