### PR TITLE
ISSUE #529 fix animation flag

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
@@ -68,7 +68,7 @@ public:
 bool SynchroModelImport::importModel(std::string filePath, uint8_t &errCode) {
 	orgFile = filePath;
 	reader = std::make_shared<synchro_reader::SynchroReader>(filePath);
-	repoInfo << "=== IMPORTING MODEL WITH SYNCHRO MODEL CONVERTOR ===";
+	repoInfo << "=== IMPORTING MODEL WITH SYNCHRO MODEL CONVERTOR (animations: " << settings.shouldImportAnimations() <<") ===";
 	std::string msg;
 	auto synchroErrCode = reader->init(msg);
 	if (synchroErrCode != synchro_reader::SynchroError::ERR_OK) {

--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -472,7 +472,7 @@ int32_t importFileAndCommit(
 
 	repo::manipulator::modelconvertor::ModelImportConfig config(true, rotate, importAnimations);
 	uint8_t err;
-	repo::core::model::RepoScene *graph = controller->loadSceneFromFile(fileLoc, err, &config);
+	repo::core::model::RepoScene *graph = controller->loadSceneFromFile(fileLoc, err, config);
 	if (graph)
 	{
 		repoLog("Trying to commit this scene to database as " + database + "." + project);


### PR DESCRIPTION
This fixes #529

#### Description
- we're passing a pointer to config instead of the actual config, which seems to result in erroneous config data.

#### Test cases
- passing in `importAnimations: false` should now ignore any transformation instructions

