### PR TITLE
ISSUE #543 fix connections for import toy

### DIFF
--- a/tools/bouncer_worker/src/lib/config.js
+++ b/tools/bouncer_worker/src/lib/config.js
@@ -49,6 +49,11 @@ const applyDefaultValuesIfUndefined = (config) => {
 	// processMonitoring
 	config.processMonitoring = config.processMonitoring || {};
 	config.processMonitoring.memoryIntervalMS = config.processMonitoring.memoryIntervalMS || 100;
+
+	// create connection string for db
+	if (!config.db.connectionString) {
+		config.db.connectionString = `mongodb://${config.db.dbhost}:${config.db.dbport}`;
+	}
 };
 /* eslint-enable no-param-reassign */
 

--- a/tools/bouncer_worker/src/tasks/importToy.js
+++ b/tools/bouncer_worker/src/tasks/importToy.js
@@ -37,7 +37,7 @@ const accumulateCollectionFiles = (modelDir, modelId) => {
 const runMongoImport = async (database, collection, filePath) => {
 	const params = [
 		'-j', '8',
-		'--host', `${config.db.dbhost}:${config.db.dbport}`,
+		'--uri', config.db.connectionString,
 		'--username', config.db.username,
 		'--password', config.db.password,
 		'--authenticationDatabase', 'admin',
@@ -248,14 +248,19 @@ const renameGroups = async (db, database, modelId) => {
 	await Promise.all(updateObjectPromises);
 };
 
+const getURLWithAuth = () => {
+	const protocol = 'mongodb://';
+	const authStr = `${config.db.username}:${encodeURIComponent(config.db.password)}@`;
+	return config.db.connectionString.replace(protocol, `${protocol}${authStr}`);
+};
+
 const ToyImporter = {};
 
 ToyImporter.importToyModel = async (toyModelID, database, modelId) => {
 	const modelDir = `${config.toyModelDir}/${toyModelID}`;
 	await importJSON(modelDir, database, modelId);
 
-	const url = `mongodb://${config.db.username}:${config.db.password}@${config.db.dbhost}:${config.db.dbport}/admin`;
-	const dbConn = await MongoClient.connect(url, { useUnifiedTopology: true });
+	const dbConn = await MongoClient.connect(getURLWithAuth(), { useUnifiedTopology: true });
 	const db = dbConn.db(database);
 
 	const promises = [];


### PR DESCRIPTION
This fixes #543

#### Description
- automatically generate `connectionString` (if undefined) when we initialise the config file 
- connection to mongo for `importToy` features now connect using `connectionString`


#### Test cases
- import toy should work:
    - when mongo connection string is given in the config instead of host and port
    - when  host and port are defined instead of mongo connection string

