### PR TITLE
Issue 558 - do not overwrite author with credentials

### DIFF
--- a/bouncer/src/repo/repo_controller_internal.cpp.inl
+++ b/bouncer/src/repo/repo_controller_internal.cpp.inl
@@ -121,18 +121,13 @@ uint8_t RepoController::_RepoControllerImpl::commitScene(
 		{
 			if (token)
 			{
-				std::string sceneOwner = owner;
-				if (!token->getCredentials())
-				{
-					sceneOwner = "ANONYMOUS USER";
-				}
 				manipulator::RepoManipulator* worker = workerPool.pop();
 				errCode = worker->commitScene(token->databaseAd,
 					token->getCredentials(),
 					token->bucketName,
 					token->bucketRegion,
 					scene,
-					sceneOwner,
+					owner.empty? "ANONYMOUS USER" : owner,
 					tag,
 					desc,
 					revId);

--- a/bouncer/src/repo/repo_controller_internal.cpp.inl
+++ b/bouncer/src/repo/repo_controller_internal.cpp.inl
@@ -127,7 +127,7 @@ uint8_t RepoController::_RepoControllerImpl::commitScene(
 					token->bucketName,
 					token->bucketRegion,
 					scene,
-					owner.empty? "ANONYMOUS USER" : owner,
+					owner.empty() ? "ANONYMOUS USER" : owner,
 					tag,
 					desc,
 					revId);

--- a/test/src/system/st_3drepobouncerClient.cpp
+++ b/test/src/system/st_3drepobouncerClient.cpp
@@ -491,7 +491,7 @@ TEST(RepoClientTest, UploadTestOwner)
 	EXPECT_TRUE(projectSettingsCheck("testDB", importNoOwnerPro, REPO_GTEST_DBUSER, "thisTag", "MyUpload"));
 	EXPECT_EQ((int)REPOERR_OK, runProcess(produceUploadFileArgs(getDataPath(importNoOwner2))));
 	EXPECT_TRUE(projectExists("testDB", importNoOwnerPro2));
-	EXPECT_TRUE(projectSettingsCheck("testDB", importNoOwnerPro2, REPO_GTEST_DBUSER, "thisTag", "MyUpload"));
+	EXPECT_TRUE(projectSettingsCheck("testDB", importNoOwnerPro2, "ANONYMOUS USER", "thisTag", "MyUpload"));
 }
 
 TEST(RepoClientTest, CreateFedTest)

--- a/test/src/system/st_3drepobouncerClient.cpp
+++ b/test/src/system/st_3drepobouncerClient.cpp
@@ -488,7 +488,7 @@ TEST(RepoClientTest, UploadTestOwner)
 
 	EXPECT_EQ((int)REPOERR_OK, runProcess(produceUploadFileArgs(getDataPath(importNoOwner))));
 	EXPECT_TRUE(projectExists("testDB", importNoOwnerPro));
-	EXPECT_TRUE(projectSettingsCheck("testDB", importNoOwnerPro, REPO_GTEST_DBUSER, "thisTag", "MyUpload"));
+	EXPECT_TRUE(projectSettingsCheck("testDB", importNoOwnerPro, "ANONYMOUS USER", "thisTag", "MyUpload"));
 	EXPECT_EQ((int)REPOERR_OK, runProcess(produceUploadFileArgs(getDataPath(importNoOwner2))));
 	EXPECT_TRUE(projectExists("testDB", importNoOwnerPro2));
 	EXPECT_TRUE(projectSettingsCheck("testDB", importNoOwnerPro2, "ANONYMOUS USER", "thisTag", "MyUpload"));

--- a/test/src/unit/repo/ut_repo_controller.cpp
+++ b/test/src/unit/repo/ut_repo_controller.cpp
@@ -61,7 +61,7 @@ TEST(RepoControllerTest, CommitScene) {
 	EXPECT_EQ(REPOERR_OK, controller->commitScene(initController(controller.get()), scene));
 	EXPECT_TRUE(scene->isRevisioned());
 	EXPECT_TRUE(projectExists("commitSceneTest", "commitCube"));
-	EXPECT_EQ(scene->getOwner(), REPO_GTEST_DBUSER);
+	EXPECT_EQ(scene->getOwner(), "ANONYMOUS USER");
 
 	auto scene2 = controller->loadSceneFromFile(getDataPath(simpleModel), errCode);
 	std::string owner = "dog";


### PR DESCRIPTION
This fixes #558

#### Description
- do not overwrite owner when we can't find credentials (not really related to model upload to begin with! Only put in anon. user if owner is not provided.


#### Test cases
- should work as usual, with the bug resolved for connections based on connection string

