### PR TITLE
ISSUE #566 fix unity process not throwing time out error

### DIFF
--- a/tools/bouncer_worker/src/tasks/unityEditor.js
+++ b/tools/bouncer_worker/src/tasks/unityEditor.js
@@ -18,7 +18,7 @@
 const fs = require('fs');
 const readline = require('readline');
 const { config, configPath } = require('../lib/config');
-const { ERRCODE_BUNDLE_GEN_FAIL, ERRCODE_UNITY_LICENCE_INVALID, ERRCODE_REPO_LICENCE_INVALID } = require('../constants/errorCodes');
+const { ERRCODE_TIMEOUT, ERRCODE_BUNDLE_GEN_FAIL, ERRCODE_UNITY_LICENCE_INVALID, ERRCODE_REPO_LICENCE_INVALID } = require('../constants/errorCodes');
 const run = require('../lib/runCommand');
 const logger = require('../lib/logger');
 const { getCurrentDateTimeAsString } = require('../lib/utils');
@@ -83,6 +83,7 @@ UnityHandler.generateAssetBundles = async (database, model, rid, logDir, process
 		switch (err) {
 			case ERRCODE_UNITY_LICENCE_INVALID:
 			case ERRCODE_REPO_LICENCE_INVALID:
+			case ERRCODE_TIMEOUT:
 				throw err;
 			default:
 				throw await checkLicenceError(unityLog) ? ERRCODE_UNITY_LICENCE_INVALID : ERRCODE_BUNDLE_GEN_FAIL;


### PR DESCRIPTION
This fixes #566

#### Description
- timeout is treated like license failures, passing the error code back to the queue instead of overwriting it with general bundle failure errorcode

#### Test cases
- a process that timed out in unity should now return the timeout error

