### PR TITLE
#572 - bump mongodb to 5.0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
           - wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
           - echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
           - sudo apt-get update
-          - sudo apt-get install -y gnupg mongodb-org=5.0.2 mongodb-org-database=5.0.2 mongodb-org-server=5.0.2 mongodb-org-shell=5.0.2 mongodb-org-tools=5.0.2
+          - sudo apt-get install -y gnupg mongodb-org=5.0.8 mongodb-org-database=5.0.8 mongodb-org-server=5.0.8 mongodb-org-shell=5.0.8 mongodb-org-tools=5.0.8
           - sudo systemctl daemon-reload && sudo systemctl start mongod && echo $(mongod --version)
           - mkdir testData && cd testData
           - svn --no-auth-cache export --username $TESTUSER --password $TESTPW https://github.com/3drepo/tests/trunk/cplusplus/bouncer


### PR DESCRIPTION
This fixes #572 

#### Description

- travis.yml updated

#### Test cases
- all usual tests should pass
