### PR TITLE
ISSUE #600 keep all data in metres in an IFC import

### DIFF
--- a/ifcUtils/repo_ifc_utils_geometry_handler.cpp
+++ b/ifcUtils/repo_ifc_utils_geometry_handler.cpp
@@ -31,7 +31,7 @@ IfcGeom::IteratorSettings createSettings()
 
 	itSettings.set(IfcGeom::IteratorSettings::WELD_VERTICES, false);
 	itSettings.set(IfcGeom::IteratorSettings::USE_WORLD_COORDS, true);
-	itSettings.set(IfcGeom::IteratorSettings::CONVERT_BACK_UNITS, true);
+	itSettings.set(IfcGeom::IteratorSettings::CONVERT_BACK_UNITS, false);
 	itSettings.set(IfcGeom::IteratorSettings::USE_BREP_DATA, false);
 	itSettings.set(IfcGeom::IteratorSettings::SEW_SHELLS, false);
 	itSettings.set(IfcGeom::IteratorSettings::FASTER_BOOLEANS, false);


### PR DESCRIPTION
This fixes #600

#### Description
unflag CONVERT_BACK_UNITS

#### Test cases
all models should now export in metres

