### PR TITLE
ISSUE #623 construct the supermesh cache file in bouncer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ matrix:
           - export OCCT_ROOT=$PWD/OCCT
           - export IFCOPENSHELL_ROOT=$PWD/IfcOpenShell
           - echo ============ TEIGHA INSTALL =============
-          - cat testData/bouncer/ext_libs/focal/teigha/2023.11/teighaLinuxGCC8.3.tgz* | tar -zxf -
+          - cat testData/focal/teigha/2023.11/teighaLinuxGCC8.3.tgz* | tar -zxf -
           - export ODA_ROOT=$PWD/teighaLinuxGCC8.3
           - export ODA_LIB_DIR=$ODA_ROOT/lib/lnxX64_8.3dll/
           - echo ============ SYNCHRO INSTALL =============

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,7 @@ matrix:
           - export OCCT_ROOT=$PWD/OCCT
           - export IFCOPENSHELL_ROOT=$PWD/IfcOpenShell
           - echo ============ TEIGHA INSTALL =============
-          - wget -q -O teighaLinuxGCC8.3.tgz $TEIGHA_LIBS_2023_11
-          - tar -zxf teighaLinuxGCC8.3.tgz
+          - cat testData/bouncer/ext_libs/focal/teigha/2023.11/teighaLinuxGCC8.3.tgz* | tar -zxf -
           - export ODA_ROOT=$PWD/teighaLinuxGCC8.3
           - export ODA_LIB_DIR=$ODA_ROOT/lib/lnxX64_8.3dll/
           - ls $ODA_ROOT/BimRv/Include/Database
@@ -132,8 +131,7 @@ matrix:
           - export OCCT_ROOT=$PWD/OCCT
           - export IFCOPENSHELL_ROOT=$PWD/IfcOpenShell
           - echo ============ TEIGHA INSTALL =============
-          - wget -q -O teighaLinuxGCC8.3.tgz $TEIGHA_LIBS_2023_11
-          - tar -zxf teighaLinuxGCC8.3.tgz
+          - cat testData/bouncer/ext_libs/focal/teigha/2023.11/teighaLinuxGCC8.3.tgz* | tar -zxf -
           - export ODA_ROOT=$PWD/teighaLinuxGCC8.3
           - export ODA_LIB_DIR=$ODA_ROOT/lib/lnxX64_8.3dll/
           - echo ============ SYNCHRO INSTALL =============


### PR DESCRIPTION
This fixes #623

#### Description
2nd part of the solution to https://github.com/3drepo/3drepo.io/issues/4212
- aggregate all unity json mappings into a single and store it as `<rev_id>/supermeshes.json`


#### Test cases
- should work as expected
- 3drepo.io should no longer need to generate this file on the fly for new model uploads

