### PR TITLE
ISSUE #629 scale transforms to the right units

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.cpp
@@ -29,15 +29,6 @@
 
 using namespace repo::manipulator::modelconvertor;
 
-float determineScaleFactor(const ModelUnits &base, const ModelUnits &target) {
-	if (base == target || base == ModelUnits::UNKNOWN || target == ModelUnits::UNKNOWN) {
-		return 1.0;
-	}
-	auto baseToM = scaleFactorToMetres(base);
-	auto mToTarget = scaleFactorFromMetres(target);
-	return baseToM * mToTarget;
-}
-
 repo::core::model::RepoScene* ModelImportManager::ImportFromFile(
 	const std::string &file,
 	const repo::manipulator::modelconvertor::ModelImportConfig &config,

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
@@ -71,7 +71,6 @@ bool SynchroModelImport::importModel(std::string filePath, uint8_t &errCode) {
 	repoInfo << "=== IMPORTING MODEL WITH SYNCHRO MODEL CONVERTOR (animations: " << settings.shouldImportAnimations() << ") ===";
 	repoInfo << "Sequence timezone is set to : " << (settings.getTimeZone().empty() ? "UTC" : settings.getTimeZone());
 
-	repoInfo << " errCode: " << errCode;
 	std::string msg;
 	auto synchroErrCode = reader->init(msg);
 	if (synchroErrCode != synchro_reader::SynchroError::ERR_OK) {
@@ -85,7 +84,6 @@ bool SynchroModelImport::importModel(std::string filePath, uint8_t &errCode) {
 		return false;
 	}
 
-	repoInfo << " errCode: " << errCode << "msg";
 	repoInfo << "Initialisation successful";
 
 	return true;

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
@@ -255,6 +255,27 @@ repo::core::model::RepoScene* SynchroModelImport::constructScene(
 
 	auto identity = repo::lib::RepoMatrix();
 	determineUnits(reader->getUnits());
+
+	auto unitsScale = determineScaleFactor(modelUnits, settings.getTargetUnits());
+	auto reverseUnitsScale = determineScaleFactor(settings.getTargetUnits(), modelUnits);
+
+	std::vector<float> scalingMatrixArr = {
+		unitsScale, 0, 0, 0,
+		0, unitsScale, 0, 0,
+		0, 0, unitsScale, 0,
+		0, 0, 0, 1
+	};
+
+	std::vector<float> reverseScalingMatrixArr = {
+		reverseUnitsScale, 0, 0, 0,
+		0, reverseUnitsScale, 0, 0,
+		0, 0, reverseUnitsScale, 0,
+		0, 0, 0, 1
+	};
+
+	scaleMatrix = repo::lib::RepoMatrix64(scalingMatrixArr);
+	reverseScaleMatrix = repo::lib::RepoMatrix64(reverseScalingMatrixArr);
+
 	auto root = createTransNode(identity, reader->getProjectName());
 	transNodes.insert(root);
 
@@ -489,7 +510,7 @@ repo::lib::RepoMatrix64 SynchroModelImport::convertMatrixTo3DRepoWorld(
 	repo::lib::RepoMatrix64 matToWorld(toWorld);
 	auto fromWorld = matToWorld.invert();
 
-	return matToWorld * matGL * matrix * matDX * fromWorld;
+	return scaleMatrix * ((matToWorld * matGL * matrix * matDX * fromWorld) * reverseScaleMatrix);
 }
 
 void SynchroModelImport::updateFrameState(
@@ -546,6 +567,7 @@ void SynchroModelImport::updateFrameState(
 				bool reset = !color.size();
 				auto colour32Bit = reset ? 0 : colourIn32Bit(color);
 				auto meshes = resourceIDsToSharedIDs.at(colourTask->resourceID);
+
 				for (const auto &mesh : meshes) {
 					meshColourState[mesh].second = reset || meshColourState[mesh].first == colour32Bit ? std::vector<float>() : color;
 				}
@@ -607,7 +629,6 @@ void SynchroModelImport::updateFrameState(
 			if (resourceIDsToSharedIDs.find(visibilityTask->resourceID) != resourceIDsToSharedIDs.end()) {
 				auto visibility = visibilityTask->visibility;
 				auto meshes = resourceIDsToSharedIDs.at(visibilityTask->resourceID);
-
 				for (const auto mesh : meshes) {
 					auto previousState = meshAlphaState[mesh].second;
 					auto meshStr = mesh.toString();
@@ -802,6 +823,7 @@ repo::core::model::RepoScene* SynchroModelImport::generateRepoScene(uint8_t &err
 				}
 
 				auto matInverse = matrix.invert();
+
 				resourceIDTransState[lastStateEntry.first] = convertMatrixTo3DRepoWorld(matInverse, offset).getData();
 			}
 		}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.cpp
@@ -70,6 +70,8 @@ bool SynchroModelImport::importModel(std::string filePath, uint8_t &errCode) {
 	reader = std::make_shared<synchro_reader::SynchroReader>(filePath, settings.getTimeZone());
 	repoInfo << "=== IMPORTING MODEL WITH SYNCHRO MODEL CONVERTOR (animations: " << settings.shouldImportAnimations() << ") ===";
 	repoInfo << "Sequence timezone is set to : " << (settings.getTimeZone().empty() ? "UTC" : settings.getTimeZone());
+
+	repoInfo << " errCode: " << errCode;
 	std::string msg;
 	auto synchroErrCode = reader->init(msg);
 	if (synchroErrCode != synchro_reader::SynchroError::ERR_OK) {
@@ -82,6 +84,8 @@ bool SynchroModelImport::importModel(std::string filePath, uint8_t &errCode) {
 		repoError << msg;
 		return false;
 	}
+
+	repoInfo << " errCode: " << errCode << "msg";
 	repoInfo << "Initialisation successful";
 
 	return true;

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_synchro.h
@@ -91,6 +91,7 @@ namespace repo {
 				const std::string TASK_START_DATE = "startDate";
 				const std::string TASK_END_DATE = "endDate";
 				const std::string TASK_CHILDREN = "subActivities";
+				repo::lib::RepoMatrix64 scaleMatrix, reverseScaleMatrix;
 
 				repo::lib::RepoMatrix64 convertMatrixTo3DRepoWorld(
 					const repo::lib::RepoMatrix64 &matrix,
@@ -204,6 +205,6 @@ namespace repo {
 				}
 #endif
 			};
-			} //namespace SynchroModelImport
-		} //namespace manipulator
-	} //namespace repo
+		} //namespace SynchroModelImport
+	} //namespace manipulator
+} //namespace repo

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_units.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_units.h
@@ -50,6 +50,14 @@ namespace repo {
 				int index = (int)units;
 				return fromMetreLookUp[index];
 			}
+			static float determineScaleFactor(const ModelUnits &base, const ModelUnits &target) {
+				if (base == target || base == ModelUnits::UNKNOWN || target == ModelUnits::UNKNOWN) {
+					return 1.0;
+				}
+				auto baseToM = scaleFactorToMetres(base);
+				auto mToTarget = scaleFactorFromMetres(target);
+				return baseToM * mToTarget;
+			}
 		}
 	}
 }

--- a/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_synchro.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_synchro.cpp
@@ -35,7 +35,7 @@ TEST(SynchroModelImport, DeconstructorTest)
 TEST(SynchroModelImport, ImportModel)
 {
 	auto import = SynchroModelImport(ModelImportConfig());
-	uint8_t errCode;
+	uint8_t errCode = 0;
 	EXPECT_TRUE(import.importModel(getDataPath(synchroVersion6_4), errCode));
 	EXPECT_EQ(0, errCode);
 


### PR DESCRIPTION
This fixes #629

#### Description
all transformations within the animations should now scale to the right units

#### Test cases
[this file](https://asitesol.sharepoint.com/:u:/s/3DRepoTeamFolder/EVgWaWoOMIdEqcvJ3c--S_YBnMHvYzn-W3T4R-N0_2UP0g?e=Y47zmw), which is in ft, has a transformation where some objects moves ~400ft on the x axis. should now work even if model settings has a different units to ft.

