### PR TITLE
ISSUE #647 Revit file crash

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -253,34 +253,40 @@ void DataProcessorRvt::convertTo3DRepoTriangle(
 
 	normalOut = calcNormal(verticesOut[0], verticesOut[1], verticesOut[2]);
 
-	std::vector<OdGePoint2d> odaUvs;
-	odaUvs.resize(verticesOut.size());
+	if (isMapperEnabled() && isMapperAvailable()) {
 
-	if (vertexData() && vertexData()->mappingCoords(OdGiVertexData::kAllChannels))
-	{
-		// Where Uvs are predefined, we need to get them for each vertex from the
-		// dedicated array using the indices again...
+		std::vector<OdGePoint2d> odaUvs;
 
-		OdGiMapperItemEntryPtr mapper = currentMapper(false)->diffuseMapper();
-		const OdGePoint3d* predefinedUvCoords = vertexData()->mappingCoords(OdGiVertexData::kAllChannels);
-		for (OdInt32 i = 0; i < verticesOut.size(); i++)
+		if (vertexData() && vertexData()->mappingCoords(OdGiVertexData::kAllChannels))
 		{
-			mapper->mapPredefinedCoords(predefinedUvCoords + indices[i], odaUvs.data() + i, 1);
-		}
-	}
-	else
-	{
-		// ...Otherwise we can look up uvs directly from the world positions
+			// Where Uvs are predefined, we need to get them for each vertex from the
+			// dedicated array using the indices again...
 
-		if (!currentMapper().isNull() && !currentMapper()->diffuseMapper().isNull())
+			OdGiMapperItemEntryPtr mapper = currentMapper(false)->diffuseMapper();
+			if (!mapper.isNull()) {
+				odaUvs.resize(verticesOut.size());
+				const OdGePoint3d* predefinedUvCoords = vertexData()->mappingCoords(OdGiVertexData::kAllChannels);
+				for (OdInt32 i = 0; i < verticesOut.size(); i++)
+				{
+					mapper->mapPredefinedCoords(predefinedUvCoords + indices[i], odaUvs.data() + i, 1);
+				}
+			}
+		}
+		else
 		{
-			currentMapper()->diffuseMapper()->mapCoords(odaPoints.data(), odaUvs.data());
-		}
-	}
+			// ...Otherwise we can look up uvs directly from the world positions
 
-	uvsOut.clear();
-	for (int i = 0; i < odaUvs.size(); ++i) {
-		uvsOut.push_back({ (float)odaUvs[i].x, (float)odaUvs[i].y });
+			if (!currentMapper(true)->diffuseMapper().isNull())
+			{
+				odaUvs.resize(verticesOut.size());
+				currentMapper()->diffuseMapper()->mapCoords(odaPoints.data(), odaUvs.data());
+			}
+		}
+
+		uvsOut.clear();
+		for (int i = 0; i < odaUvs.size(); ++i) {
+			uvsOut.push_back({ (float)odaUvs[i].x, (float)odaUvs[i].y });
+		}
 	}
 }
 


### PR DESCRIPTION


This fixes #647 

#### Description
This PR adds additional checks around the `OdGiMapper`, used to transform UVs when getting the geometry data.

Our use of this is based on the Kernel SDK's ColladaExportView sample.

Previously, we checked for vertex attributes and assumed if they were present, that a mapper would be available, but on some files this is not true. This PR adds a check using the dedicated `isMapperEnabled` and `isMapperAvailable` methods before trying to use it.

Though we checked for attributes before, it is possible the vertex data includes attributes other than UVs - at the moment, ODA has only one possible parameter for the mapping channels, kAllChannels, but just because we can't specify diffuse texture coords, doesn't mine others can't exist.

Another (probably more likely) explanation for this case (attributes but no mapper) is that the mapper is not created when the view has the Hidden style (as no textures are shown), but the geometry is defined with Uvs, which is the condition that triggers us to try and process them. The example failing model had the `{3D}` view set to the Hidden style.

#### Test cases
The file attached in the #647 is imported with the changes, and succeeds and shows in the viewer. Setting the style of the `{3D}` view to Textures and reimporting also shows the textures in the viewer.
