### PR TITLE
ISSUE 651 - Missing Metadata

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -24,6 +24,7 @@
 #include "../../../../lib/repo_utils.h"
 #include <Database/BmTransaction.h>
 #include <Database/BmUnitUtils.h>
+#include <Database/Entities/BmRbsSystemType.h>
 #include <Base/BmForgeTypeId.h>
 #include <Base/BmParameterSet.h>
 #include <Base/BmSpecTypeId.h>
@@ -321,6 +322,17 @@ void DataProcessorRvt::fillMeshData(const OdGiDrawable* pDrawable)
 
 	if (!element->isDBRO())
 		return;
+
+	// In the current version of ODA, each component that is a member of a
+	// system is followed by that system as an OdGiDrawable, so we need the
+	// geometry to be associated with the previous OdGiDrawable. This is
+	// achieved by simply skipping all system drawables (and so not changing
+	// the collector settings).
+
+	if (element->isKindOf(OdBmRbsSystemType::desc()))
+	{
+		return;
+	}
 
 	collector->stopMeshEntry();
 

--- a/test/src/system/st_3drepobouncerClient.cpp
+++ b/test/src/system/st_3drepobouncerClient.cpp
@@ -505,6 +505,19 @@ TEST(RepoClientTest, UploadTestRVTRegressionTests)
 	std::string rvtUpload7 = produceUploadArgs(db, "rvtTest7", getDataPath(rvtHouse));
 	EXPECT_EQ((int)REPOERR_LOAD_SCENE_MISSING_TEXTURE, runProcess(rvtUpload7));
 	EXPECT_TRUE(projectExists(db, "rvtTest7"));
+
+	// Check if the metadata applied to geometric elements connected to MEP
+	// systems is correct
+	std::string rvtUpload8 = produceUploadArgs(db, "rvtTest8", getDataPath(rvtMeta3));
+	EXPECT_EQ((int)REPOERR_OK, runProcess(rvtUpload8));
+	EXPECT_TRUE(projectExists(db, "rvtTest8"));
+	// In rvtMeta3, some of these elements belong to systems, and others do not
+	EXPECT_TRUE(projectHasGeometryWithMetadata(db, "rvtTest8", "Element ID", "702167"));
+	EXPECT_TRUE(projectHasGeometryWithMetadata(db, "rvtTest8", "Element ID", "702041"));
+	EXPECT_TRUE(projectHasGeometryWithMetadata(db, "rvtTest8", "Element ID", "706118"));
+	EXPECT_TRUE(projectHasGeometryWithMetadata(db, "rvtTest8", "Element ID", "706347"));
+	EXPECT_TRUE(projectHasGeometryWithMetadata(db, "rvtTest8", "Element ID", "703971"));
+	EXPECT_TRUE(projectHasGeometryWithMetadata(db, "rvtTest8", "Element ID", "704116"));
 }
 
 TEST(RepoClientTest, UploadTestMissingFieldsInJSON)

--- a/test/src/unit/repo_test_database_info.h
+++ b/test/src/unit/repo_test_database_info.h
@@ -63,6 +63,7 @@ const static std::string rvtNo3DViewModel = "sample_bad.rvt";
 const static std::string rvtRoofTest = "RoofTest.rvt";
 const static std::string rvtMeta1 = "MetaTest1.rvt";
 const static std::string rvtMeta2 = "MetaTest2.rvt";
+const static std::string rvtMeta3 = "MetaTest3.rvt";
 const static std::string rvtHouse = "sampleHouse.rvt";
 const static std::string unsupportedFBXVersion = "unsupported.FBX";
 const static std::string synchroFile = "synchro.spm";


### PR DESCRIPTION
This fixes #651 

#### Description
This bug was caused by ODA outputting an OdGiDrawable for a MEP System Type, for each element connected to a system, where the geometry for an element appeared under the second drawable.

This PR adds a check which ignores any OdGiDrawable that derives from a MEP System Type (`OdBmRbsSystemType`). Since the Geometry Collector is set up by the prior (true) element, ignoring the metadata/geometry collector configuration in `fillMeshData` means the geometry output by the `OdGsBaseMaterialView::draw(pDrawable)` call ends up in the original element, along with its original metadata.

A unit test has been added containing elements for HVAC, Plumbing and Electrical Systems.

#657 should be merged to staging first, as this branch has #647 merged into it so all the imports succeed.

#### Test cases
A minimal working example, rvtMeta3, has been added to the tests repo.
