### PR TITLE
Issue 608 Provide better reasoning in the log for failures to write to file system

### DIFF
--- a/bouncer/src/repo/lib/repo_utils.h
+++ b/bouncer/src/repo/lib/repo_utils.h
@@ -60,5 +60,25 @@ namespace repo {
 			char* value = getenv(envVarName.c_str());
 			return (value && strlen(value) > 0) ? value : "";
 		}
+
+		static bool hasFileWritePermissions(const boost::filesystem::path& inputPath) 
+		{
+		
+			boost::filesystem::file_status s = boost::filesystem::status(inputPath);
+			if (boost::filesystem::perms::owner_write == s.permissions()) {
+				return true;
+			}
+			return false;
+		}
+
+		static bool isFileWritingSpaceAvailable(const boost::filesystem::path& inputPath) 
+		{
+			boost::filesystem::path pathWithoutFileName = inputPath;
+			boost::filesystem::space_info spaceInfo = boost::filesystem::space(pathWithoutFileName.remove_filename());
+			if (spaceInfo.free > (boost::filesystem::file_size(inputPath) + 1)) {
+				return true;
+			}
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
…to file system

Added functions to check the file writing permissions and also check the free disk size before writing the file on the disk.

This fixes #608

#### Description
Added functions to check the file writing permission and also to check if the size on the disk is free or not to get proper error descriptions in the log.


