### PR TITLE
ISSUE #515 FBX rotated on axis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
           - tar -zxf testData/bouncer/ext_libs/focal/mongo-cxx-driver.tgz
           - export MONGO_ROOT=$PWD/mongo-cxx-driver
           - echo ============ ASSIMP INSTALL =============
-          - tar -zxf testData/bouncer/ext_libs/focal/assimp.tgz
+          - tar -zxf testData/bouncer/ext_libs/focal/assimp-5.0.1.tgz
           - export ASSIMP_ROOT=$PWD/assimp
           - echo ============ IFCOPENSHELL INSTALL =============
           - tar -zxf testData/bouncer/ext_libs/focal/IfcOpenShell_v0.6.0/OCCT_3drepoFix.tgz
@@ -126,7 +126,7 @@ matrix:
           - tar -zxf testData/focal/mongo-cxx-driver.tgz
           - export MONGO_ROOT=$PWD/mongo-cxx-driver
           - echo ============ ASSIMP INSTALL =============
-          - tar -zxf testData/focal/assimp.tgz
+          - tar -zxf testData/focal/assimp-5.0.1.tgz
           - export ASSIMP_ROOT=$PWD/assimp
           - echo ============ IFCOPENSHELL INSTALL =============
           - tar -zxf testData/focal/IfcOpenShell_v0.6.0/OCCT_3drepoFix.tgz

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_assimp.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_assimp.cpp
@@ -1330,6 +1330,8 @@ bool AssimpModelImport::SetRootOrientationFromMetadata()
 	reqMetadataExists &= assimpScene->mMetaData->Get<int32_t>("FrontAxisSign", frontAxisSign);
 	reqMetadataExists &= assimpScene->mMetaData->Get<int32_t>("CoordAxis", coordAxis);
 	reqMetadataExists &= assimpScene->mMetaData->Get<int32_t>("CoordAxisSign", coordAxisSign);
+	repoInfo << "reqMetadataExists=" << (reqMetadataExists) ? "true" : "false";
+	repoInfo <<"UpAxis="<< upAxis<<" UpAxisSign="<< upAxisSign<< " FrontAxis=" << frontAxis << " FrontAxisSign=" << frontAxisSign << " CoordAxis=" << coordAxis << " CoordAxisSign=" << coordAxisSign;
 	if (!reqMetadataExists) return false;
 
 	// create the transformation

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_assimp.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_assimp.cpp
@@ -1330,8 +1330,6 @@ bool AssimpModelImport::SetRootOrientationFromMetadata()
 	reqMetadataExists &= assimpScene->mMetaData->Get<int32_t>("FrontAxisSign", frontAxisSign);
 	reqMetadataExists &= assimpScene->mMetaData->Get<int32_t>("CoordAxis", coordAxis);
 	reqMetadataExists &= assimpScene->mMetaData->Get<int32_t>("CoordAxisSign", coordAxisSign);
-	repoInfo << "reqMetadataExists=" << (reqMetadataExists) ? "true" : "false";
-	repoInfo <<"UpAxis="<< upAxis<<" UpAxisSign="<< upAxisSign<< " FrontAxis=" << frontAxis << " FrontAxisSign=" << frontAxisSign << " CoordAxis=" << coordAxis << " CoordAxisSign=" << coordAxisSign;
 	if (!reqMetadataExists) return false;
 
 	// create the transformation

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_config.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_config.h
@@ -38,7 +38,6 @@ namespace repo {
 			{
 			private:
 				bool applyReductions;
-				bool rotateModel;
 				bool importAnimations;
 				int lod;
 				std::string timeZone;
@@ -46,22 +45,19 @@ namespace repo {
 			public:
 				ModelImportConfig(
 					const bool applyReductions = true,
-					const bool rotateModel = false,
 					const bool importAnimations = true,
 					const ModelUnits targetUnits = ModelUnits::UNKNOWN,
 					const std::string timeZone = "",
 					const int lod = 0) :
-					applyReductions(applyReductions), 
-					rotateModel(rotateModel), 
-					importAnimations(importAnimations), 
-					targetUnits(targetUnits), 
-					timeZone(timeZone), 
+					applyReductions(applyReductions),
+					importAnimations(importAnimations),
+					targetUnits(targetUnits),
+					timeZone(timeZone),
 					lod(lod) {}
 
 				~ModelImportConfig() {}
 
 				bool shouldApplyReductions() const { return applyReductions; }
-				bool shouldRotateModel() const { return rotateModel; }
 				bool shouldImportAnimations() const { return importAnimations; }
 				std::string getTimeZone() const { return timeZone; }
 				ModelUnits getTargetUnits() const { return targetUnits; }

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.cpp
@@ -74,7 +74,7 @@ repo::core::model::RepoScene* ModelImportManager::ImportFromFile(
 				error = REPOERR_NO_MESHES;
 			}
 			else {
-				if (config.shouldRotateModel() || modelConvertor->requireReorientation()) {
+				if (modelConvertor->requireReorientation()) {
 					repoTrace << "rotating model by 270 degress on the x axis...";
 					scene->reorientateDirectXModel();
 				}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.cpp
@@ -74,7 +74,10 @@ repo::core::model::RepoScene* ModelImportManager::ImportFromFile(
 				error = REPOERR_NO_MESHES;
 			}
 			else {
-				if (modelConvertor->requireReorientation()) {
+				std::string ext = repo::lib::getExtension(file);
+				repo::lib::toLower(ext);
+				bool isFbxFile = ext == ".fbx";
+				if ((config.shouldRotateModel() && !isFbxFile) || modelConvertor->requireReorientation()) {
 					repoTrace << "rotating model by 270 degress on the x axis...";
 					scene->reorientateDirectXModel();
 				}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.cpp
@@ -74,10 +74,7 @@ repo::core::model::RepoScene* ModelImportManager::ImportFromFile(
 				error = REPOERR_NO_MESHES;
 			}
 			else {
-				std::string ext = repo::lib::getExtension(file);
-				repo::lib::toLower(ext);
-				bool isFbxFile = ext == ".fbx";
-				if ((config.shouldRotateModel() && !isFbxFile) || modelConvertor->requireReorientation()) {
+				if (config.shouldRotateModel() || modelConvertor->requireReorientation()) {
 					repoTrace << "rotating model by 270 degress on the x axis...";
 					scene->reorientateDirectXModel();
 				}

--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -427,7 +427,6 @@ int32_t importFileAndCommit(
 			timeZone = jsonTree.get<std::string>("timezone", "");
 			units = jsonTree.get<std::string>("units", "");
 			lod = jsonTree.get<int>("lod", 0);
-			rotate = jsonTree.get<bool>("dxrotate", rotate);
 			importAnimations = jsonTree.get<bool>("importAnimations", importAnimations);
 			fileLoc = jsonTree.get<std::string>("file", "");
 			auto revIdStr = jsonTree.get<std::string>("revId", "");
@@ -453,33 +452,13 @@ int32_t importFileAndCommit(
 
 		if (command.nArgcs > 3)
 		{
-			//If 3rd argument is "dxrotate", we need to rotate the X axis
-			//Otherwise the user is trying to name the owner, rotate is false.
-			std::string arg3 = command.args[3];
-			if (arg3 == "dxrotate")
-			{
-				rotate = true;
-			}
-			else
-			{
-				owner = command.args[3];
-			}
-		}
-		if (command.nArgcs > 4)
-		{
-			//If the last argument is rotate, this is owner
-			//otherwise this is configFile (confusing, I know.)
-			if (rotate)
-			{
-				owner = command.args[4];
-			}
+			owner = command.args[3];
 		}
 	}
 
 	boost::filesystem::path filePath(fileLoc);
 	std::string fileExt = filePath.extension().string();
 	std::transform(fileExt.begin(), fileExt.end(), fileExt.begin(), ::toupper);
-	rotate &= fileExt != FBX_EXTENSION;
 
 	auto targetUnits = repo::manipulator::modelconvertor::ModelUnits::UNKNOWN;
 
@@ -491,12 +470,11 @@ int32_t importFileAndCommit(
 	//Something like this: http://stackoverflow.com/questions/15541498/how-to-implement-subcommands-using-boost-program-options
 
 	repoLog("File: " + fileLoc + " database: " + database
-		+ " project: " + project + " target units: " + (units.empty() ? "none" : units) + " rotate: "
-		+ (rotate ? "true" : "false") + " owner :" + owner + " importAnimations: " + (importAnimations ? "true" : "false")
+		+ " project: " + project + " target units: " + (units.empty() ? "none" : units) + " owner :" + owner + " importAnimations: " + (importAnimations ? "true" : "false")
 		+ " lod: " + std::to_string(lod)
 	);
 
-	repo::manipulator::modelconvertor::ModelImportConfig config(true, rotate, importAnimations, targetUnits, timeZone, lod);
+	repo::manipulator::modelconvertor::ModelImportConfig config(true, importAnimations, targetUnits, timeZone, lod);
 	uint8_t err;
 	repo::core::model::RepoScene *graph = controller->loadSceneFromFile(fileLoc, err, config);
 	if (graph)

--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -479,7 +479,7 @@ int32_t importFileAndCommit(
 	boost::filesystem::path filePath(fileLoc);
 	std::string fileExt = filePath.extension().string();
 	std::transform(fileExt.begin(), fileExt.end(), fileExt.begin(), ::toupper);
-	rotate |= fileExt == FBX_EXTENSION;
+	rotate &= fileExt != FBX_EXTENSION;
 
 	auto targetUnits = repo::manipulator::modelconvertor::ModelUnits::UNKNOWN;
 

--- a/cmake_modules/FindASSIMPM.cmake
+++ b/cmake_modules/FindASSIMPM.cmake
@@ -25,11 +25,11 @@ if(DEFINED ENV{ASSIMP_ROOT})
 	find_path(ASSIMP_INCLUDE_DIR assimp
 		${ASSIMP_ROOT}/include
 		)    
-	find_library(ASSIMP_LIBRARIES_RELEASE NAMES assimp-vc120-mt assimp-vc130-mt assimp-vc140-mt assimp
+	find_library(ASSIMP_LIBRARIES_RELEASE NAMES assimp-vc120-mt assimp-vc130-mt assimp-vc140-mt assimp-vc143-mt assimp
 		PATHS
 		${ASSIMP_ROOT}/lib
 	)	
-	find_library(ASSIMP_LIBRARIES_DEBUG NAMES assimp-vc120-mtd assimp-vc130-mtd assimp-vc130-mt assimp-vc140-mt  assimp-vc140-mtd assimp-vc120-mt assimpd assimp
+	find_library(ASSIMP_LIBRARIES_DEBUG NAMES assimp-vc120-mtd assimp-vc130-mtd assimp-vc130-mt assimp-vc140-mt assimp-vc140-mtd assimp-vc143-mtd assimp-vc143-mt assimp-vc120-mt assimpd assimp
 		PATHS
 		${ASSIMP_ROOT}/lib
 	)

--- a/test/src/unit/repo/ut_repo_controller.cpp
+++ b/test/src/unit/repo/ut_repo_controller.cpp
@@ -104,17 +104,6 @@ TEST(RepoControllerTest, LoadSceneFromFile) {
 	EXPECT_TRUE(sceneNoReduction->getAllTransformations(defaultG).size()
 			> scene->getAllTransformations(defaultG).size());
 
-	//Import the scene with root trans rotated
-	auto sceneRotated = controller->loadSceneFromFile(getDataPath(simpleModel), errCode, repo::manipulator::modelconvertor::ModelImportConfig(true, true));
-	EXPECT_EQ(errCode, 0);
-	EXPECT_TRUE(sceneRotated);
-	ASSERT_TRUE(sceneRotated->getRoot(defaultG));
-	EXPECT_TRUE(sceneRotated->getRoot(optG));
-	EXPECT_FALSE(sceneRotated->isMissingTexture());
-	//The root transformation should not be an identity
-	core::model::TransformationNode *rootTrans = dynamic_cast<core::model::TransformationNode*>(sceneRotated->getRoot(defaultG));
-	EXPECT_FALSE(rootTrans->isIdentity());
-
 	//Import the scene with non existant file
 	auto sceneNoFile = controller->loadSceneFromFile("thisFileDoesntExist.obj", errCode);
 	EXPECT_EQ(errCode, REPOERR_MODEL_FILE_READ);

--- a/test/src/unit/repo/ut_repo_controller.cpp
+++ b/test/src/unit/repo/ut_repo_controller.cpp
@@ -105,7 +105,7 @@ TEST(RepoControllerTest, LoadSceneFromFile) {
 			> scene->getAllTransformations(defaultG).size());
 
 	//Import the scene with root trans rotated
-	auto sceneRotated = controller->loadSceneFromFile(getDataPath(simpleModel), errCode, repo::manipulator::modelconvertor::ModelImportConfig(true, true, true));
+	auto sceneRotated = controller->loadSceneFromFile(getDataPath(simpleModel), errCode, repo::manipulator::modelconvertor::ModelImportConfig(true, true));
 	EXPECT_EQ(errCode, 0);
 	EXPECT_TRUE(sceneRotated);
 	ASSERT_TRUE(sceneRotated->getRoot(defaultG));


### PR DESCRIPTION
This fixes #515

#### Description
Assimp supported model file rotation is done by file model convertor available in global settings. 
We need to upgrade assimp library to at least 5.X.X version for fetching "GlobalSetting" from assimp file. 
I have done with following assimp branch **https://github.com/assimp/assimp/tree/v5.3.1**