### PR TITLE
ISSUE #664 Remove redundant transformation that is preventing metadata from referencing the right object

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_3drepo.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_3drepo.cpp
@@ -378,15 +378,14 @@ void RepoModelImport::createObject(const ptree& tree)
 	repo::lib::RepoMatrix parentTransform = trans_matrix_map[myParent];
 
 	boost::optional< const ptree& > transMatTree = tree.get_child_optional("transformation");
-	
+
 	repo::core::model::TransformationNode* transNode = (repo::core::model::TransformationNode*) node_map[myParent];
 
-	// We only want to create a node if there is a matrix transformation to represent, or 
+	// We only want to create a node if there is a matrix transformation to represent, or
 	// we're trying to represent a different entity to its parent. Otherwise, reuse the parent transform and only store the geometry
 	bool isEntity = !transName.empty() || transMatTree;
 
 	if (isEntity) {
-	
 		if (transMatTree) {
 			repo::lib::RepoMatrix transMat = repo::lib::RepoMatrix(as_vector<float>(tree, "transformation"));
 			trans_matrix_map.push_back(parentTransform * transMat);
@@ -431,8 +430,6 @@ void RepoModelImport::createObject(const ptree& tree)
 			*meta = meta->cloneAndAddParent(metaParentIDs);
 		}
 	}
-
-	
 }
 
 void RepoModelImport::skipAheadInFile(long amount)
@@ -607,7 +604,7 @@ boost::property_tree::ptree RepoModelImport::getNextJSON(long jsonSize)
 repo::core::model::RepoScene* RepoModelImport::generateRepoScene(uint8_t& errCode)
 {
 	repoInfo << "Generating scene";
-	
+
 	// Process root node
 	boost::property_tree::ptree root = getNextJSON(sizes[1]);
 	std::string rootName = root.get<std::string>("name", "");

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_3drepo.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_3drepo.cpp
@@ -378,9 +378,7 @@ void RepoModelImport::createObject(const ptree& tree)
 	repo::lib::RepoMatrix parentTransform = trans_matrix_map[myParent];
 
 	boost::optional< const ptree& > transMatTree = tree.get_child_optional("transformation");
-	if (node_map.size() <= myParent) {
-		repoError << "Unexpected node count, has " << node_map.size() << " trying to reference " << myParent;
-	}
+	
 	repo::core::model::TransformationNode* transNode = (repo::core::model::TransformationNode*) node_map[myParent];
 
 	// We only want to create a node if there is a matrix transformation to represent, or 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_3drepo.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_3drepo.cpp
@@ -374,34 +374,36 @@ void RepoModelImport::createObject(const ptree& tree)
 
 	std::string transName = tree.get<std::string>("name", "");
 
-	if (myParent > node_map.size())
-	{
-		repoError << "Invalid parent ID: " << myParent;
-	}
-
 	repo::lib::RepoUUID parentSharedID = node_map[myParent]->getSharedID();
 	repo::lib::RepoMatrix parentTransform = trans_matrix_map[myParent];
 
-	std::vector<repo::lib::RepoUUID> parentIDs;
-	parentIDs.push_back(parentSharedID);
-
 	boost::optional< const ptree& > transMatTree = tree.get_child_optional("transformation");
-
-	repo::lib::RepoMatrix transMat;
-
-	if (transMatTree)
-	{
-		transMat = repo::lib::RepoMatrix(as_vector<float>(tree, "transformation"));
+	if (node_map.size() <= myParent) {
+		repoError << "Unexpected node count, has " << node_map.size() << " trying to reference " << myParent;
 	}
+	repo::core::model::TransformationNode* transNode = (repo::core::model::TransformationNode*) node_map[myParent];
 
-	trans_matrix_map.push_back(parentTransform * transMat);
+	// We only want to create a node if there is a matrix transformation to represent, or 
+	// we're trying to represent a different entity to its parent. Otherwise, reuse the parent transform and only store the geometry
+	bool isEntity = !transName.empty() || transMatTree;
 
-	repo::core::model::TransformationNode* transNode =
-		new repo::core::model::TransformationNode(
-			repo::core::model::RepoBSONFactory::makeTransformationNode(repo::lib::RepoMatrix(), transName, parentIDs));
-
-	repo::lib::RepoUUID transID = transNode->getSharedID();
-
+	if (isEntity) {
+	
+		if (transMatTree) {
+			repo::lib::RepoMatrix transMat = repo::lib::RepoMatrix(as_vector<float>(tree, "transformation"));
+			trans_matrix_map.push_back(parentTransform * transMat);
+		}
+		else {
+			trans_matrix_map.push_back(parentTransform);
+		}
+		transNode =
+			new repo::core::model::TransformationNode(
+				repo::core::model::RepoBSONFactory::makeTransformationNode(repo::lib::RepoMatrix(), transName, { parentSharedID }));
+		transformations.insert(transNode);
+	}
+	else {
+		trans_matrix_map.push_back(parentTransform);
+	}
 	node_map.push_back(transNode);
 
 	std::vector<repo::core::model::MetadataNode*> metas;
@@ -409,27 +411,30 @@ void RepoModelImport::createObject(const ptree& tree)
 
 	for (ptree::const_iterator props = tree.begin(); props != tree.end(); props++)
 	{
-		if (props->first == REPO_IMPORT_METADATA)
+		if (isEntity && props->first == REPO_IMPORT_METADATA)
 		{
+			// The assumption is that if the entry is not an individual entity, we don't want to import the metadata.
 			metas.push_back(createMetadataNode(props->second, transName, parentSharedID));
 		}
 
 		if (props->first == REPO_IMPORT_GEOMETRY)
 		{
-			auto mesh = createMeshRecord(props->second, transName, transID, trans_matrix_map.back());
+			auto mesh = createMeshRecord(props->second, transNode->getName(), transNode->getSharedID(), trans_matrix_map.back());
 			metaParentIDs.push_back(mesh.sharedID);
 			meshEntries.push_back(mesh);
 		}
 	}
 
-	metaParentIDs.push_back(transNode->getSharedID());
+	if (isEntity) {
+		metaParentIDs.push_back(transNode->getSharedID());
 
-	for (auto& meta : metas)
-	{
-		*meta = meta->cloneAndAddParent(metaParentIDs);
+		for (auto& meta : metas)
+		{
+			*meta = meta->cloneAndAddParent(metaParentIDs);
+		}
 	}
 
-	transformations.insert(transNode);
+	
 }
 
 void RepoModelImport::skipAheadInFile(long amount)
@@ -604,7 +609,7 @@ boost::property_tree::ptree RepoModelImport::getNextJSON(long jsonSize)
 repo::core::model::RepoScene* RepoModelImport::generateRepoScene(uint8_t& errCode)
 {
 	repoInfo << "Generating scene";
-
+	
 	// Process root node
 	boost::property_tree::ptree root = getNextJSON(sizes[1]);
 	std::string rootName = root.get<std::string>("name", "");


### PR DESCRIPTION
This fixes #664

#### Description
Turns out we already optimise the first level of transformation. The problem lies on the model exporter in the plugins (issue addressed here https://github.com/3drepo/3drepoPlugin/issues/435) - for a node with geometry, it is exporting 2 transformations and a mesh....

To fix any existing .bim files or users using an older version of the plugins, the following change is made here:
- If a node has no name or a transformation, do not port it into 3drepo as a transformation node, instead, append its geometry to the parent of this node.

#### Test cases
Test case described in 664 should now function as expected

