### PR TITLE
Issue 675 - do not write UV channel count if we're not writing UVs

### DIFF
--- a/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
@@ -453,9 +453,6 @@ MeshNode RepoBSONFactory::makeMeshNode(
 	// UV channels
 	if (uvChannels.size() > 0)
 	{
-		// Could be unsigned __int64 if BSON had such construct (the closest is only __int64)
-		builder.append(REPO_NODE_MESH_LABEL_UV_CHANNELS_COUNT, (uint32_t)(uvChannels.size()));
-
 		std::vector<repo::lib::RepoVector2D> concatenated;
 
 		for (auto it = uvChannels.begin(); it != uvChannels.end(); ++it)
@@ -471,25 +468,30 @@ MeshNode RepoBSONFactory::makeMeshNode(
 
 		uint64_t uvByteCount = concatenated.size() * sizeof(concatenated[0]);
 
-		if (uvByteCount + bytesize >= REPO_BSON_MAX_BYTE_SIZE)
-		{
-			std::string bName = uniqueID.toString() + "_uv";
-			//inclusion of this binary exceeds the maximum, store separately
-			binMapping[REPO_NODE_MESH_LABEL_UV_CHANNELS] =
-				std::pair<std::string, std::vector<uint8_t>>(bName, std::vector<uint8_t>());
-			binMapping[REPO_NODE_MESH_LABEL_UV_CHANNELS].second.resize(uvByteCount); //uint8_t will ensure it is a byte addrressing
-			memcpy(binMapping[REPO_NODE_MESH_LABEL_UV_CHANNELS].second.data(), &concatenated[0], uvByteCount);
+		if (uvByteCount > 0) {
+			// Could be unsigned __int64 if BSON had such construct (the closest is only __int64)
+			builder.append(REPO_NODE_MESH_LABEL_UV_CHANNELS_COUNT, (uint32_t)(uvChannels.size()));
 
-			bytesize += sizeof(bName);
-		}
-		else if(uvByteCount > 0)
-		{
-			builder.appendBinary(
-				REPO_NODE_MESH_LABEL_UV_CHANNELS,
-				&concatenated[0],
-				concatenated.size() * sizeof(concatenated[0]));
+			if (uvByteCount + bytesize >= REPO_BSON_MAX_BYTE_SIZE)
+			{
+				std::string bName = uniqueID.toString() + "_uv";
+				//inclusion of this binary exceeds the maximum, store separately
+				binMapping[REPO_NODE_MESH_LABEL_UV_CHANNELS] =
+					std::pair<std::string, std::vector<uint8_t>>(bName, std::vector<uint8_t>());
+				binMapping[REPO_NODE_MESH_LABEL_UV_CHANNELS].second.resize(uvByteCount); //uint8_t will ensure it is a byte addrressing
+				memcpy(binMapping[REPO_NODE_MESH_LABEL_UV_CHANNELS].second.data(), &concatenated[0], uvByteCount);
 
-			bytesize += uvByteCount;
+				bytesize += sizeof(bName);
+			}
+			else
+			{
+				builder.appendBinary(
+					REPO_NODE_MESH_LABEL_UV_CHANNELS,
+					&concatenated[0],
+					concatenated.size() * sizeof(concatenated[0]));
+
+				bytesize += uvByteCount;
+			}
 		}
 	}
 

--- a/test/src/system/st_3drepobouncerClient.cpp
+++ b/test/src/system/st_3drepobouncerClient.cpp
@@ -482,6 +482,10 @@ TEST(RepoClientTest, UploadTestSPM)
 	std::string spmUpload5 = produceUploadArgs(db, "synchroTest5", getDataPath(synchroVersion6_5));
 	EXPECT_EQ((int)REPOERR_OK, runProcess(spmUpload5));
 	EXPECT_TRUE(projectExists(db, "synchroTest5"));
+
+	std::string spmUpload6 = produceUploadArgs(db, "synchroTest6", getDataPath(synchroVersion6_5_3_7));
+	EXPECT_EQ((int)REPOERR_OK, runProcess(spmUpload6));
+	EXPECT_TRUE(projectExists(db, "synchroTest6"));
 }
 
 TEST(RepoClientTest, UploadTestRVTRegressionTests)

--- a/test/src/unit/repo_test_database_info.h
+++ b/test/src/unit/repo_test_database_info.h
@@ -72,6 +72,7 @@ const static std::string synchroOldVersion = "synchro6_1.spm";
 const static std::string synchroVersion6_3 = "synchro6_3.spm";
 const static std::string synchroVersion6_4 = "synchro6_4.spm";
 const static std::string synchroVersion6_5 = "synchro6_5.spm";
+const static std::string synchroVersion6_5_3_7 = "synchro6_5_3_7.spm";
 
 const static std::string emptyFile = "empty.json";
 const static std::string emptyJSONFile = "empty2.json";

--- a/tools/release/git_release.py
+++ b/tools/release/git_release.py
@@ -71,9 +71,6 @@ updateCmake(majorV, minorTag);
 updateSrcHeaders(majorV, minorTag);
 updateBouncerWorker(version)
 
-execExitOnFail("git clean -f -d", "Failed to clean directory")
-
-
 execExitOnFail("git commit -m \"Version " + version + "\"", "Failed to commit")
 
 execExitOnFail("git push origin :refs/tags/" + version, "Failed to push tag")


### PR DESCRIPTION
This fixes #675
#### Description
Fixes a bug when Synchro importer sometimes gives us empty UV channels, we are not storing an empty buffer to match but the UV channel is still recorded as > 0


#### Test cases
the 2 models in the sharepoint folder should now import successfully.

