### PR TITLE
Issue 683 - clear the default graph as soon as possible

### DIFF
--- a/bouncer/src/repo/core/model/collection/repo_scene.cpp
+++ b/bouncer/src/repo/core/model/collection/repo_scene.cpp
@@ -97,6 +97,8 @@ RepoScene::RepoScene(
 {
 	graph.rootNode = nullptr;
 	stashGraph.rootNode = nullptr;
+	graph.cleared = false;
+	stashGraph.cleared = false;
 	//defaults to master branch
 	branch = repo::lib::RepoUUID(REPO_HISTORY_MASTER_BRANCH);
 }
@@ -122,6 +124,8 @@ RepoScene::RepoScene(
 {
 	graph.rootNode = nullptr;
 	stashGraph.rootNode = nullptr;
+	graph.cleared = false;
+	stashGraph.cleared = false;
 	branch = repo::lib::RepoUUID(REPO_HISTORY_MASTER_BRANCH);
 	populateAndUpdate(GraphType::DEFAULT, cameras, meshes, materials, metadata, textures, transformations, references, unknowns);
 }

--- a/bouncer/src/repo/core/model/collection/repo_scene.h
+++ b/bouncer/src/repo/core/model/collection/repo_scene.h
@@ -1063,7 +1063,7 @@ namespace repo {
 					auto& g = (gType == GraphType::OPTIMIZED) ? stashGraph : graph;
 					if (g.cleared)
 					{
-						throw std::exception("Attempting to access a cleared graph.");
+						throw std::logic_error("Attempting to access a cleared graph.");
 					}
 					return g;
 				}
@@ -1073,7 +1073,7 @@ namespace repo {
 					auto& g = (gType == GraphType::OPTIMIZED) ? stashGraph : graph;
 					if (g.cleared)
 					{
-						throw std::exception("Attempting to access a cleared graph.");
+						throw std::logic_error("Attempting to access a cleared graph.");
 					}
 					return g;
 				}

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
@@ -160,6 +160,8 @@ uint8_t SceneManager::commitScene(
 					repoError << "failed to commit selection tree";
 			}
 
+			scene->clearGraph(repo::core::model::RepoScene::GraphType::DEFAULT); // Free up some memory as we'll only work with the stash graph from here on in
+
 			if (success)
 			{
 				if (shouldGenerateSrcFiles(scene, handler))


### PR DESCRIPTION
This fixes #683.

#### Description

This PR makes a very small functional change, in that the default graph is cleared after `generateAndCommitSelectionTree` returns. 

However, bouncer often accesses the graphs by iterating over their members, and both the graphs and members are non-nullable. Therefore this PR also makes almost all accesses to the graphs go through a method that checks if the graph has been explicitly cleared, and throws an exception if this is the case, to make certain no accesses to default take place once it has been cleared.

The purpose of this change is to reduce the peak memory of bouncer by freeing the default graph once it is no longer used.