### PR TITLE
Issue 695 - Milestone 5: Autocalibration

### DIFF
--- a/bouncer/src/repo/core/model/bson/CMakeLists.txt
+++ b/bouncer/src/repo/core/model/bson/CMakeLists.txt
@@ -36,6 +36,7 @@ set(HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_bson_assets.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_bson_binmapping_builder.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_bson_builder.h
+	${CMAKE_CURRENT_SOURCE_DIR}/repo_bson_calibration.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_bson_element.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_bson_factory.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_bson_project_settings.h

--- a/bouncer/src/repo/core/model/bson/repo_bson_calibration.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_calibration.h
@@ -15,35 +15,28 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+/**
+*  Assets BSON
+*/
+
 #pragma once
 
-#include <string>
-#include <vector>
-#include "repo/lib/datastructure/repo_vector.h"
+#include "repo_bson.h"
 
 namespace repo {
-	namespace manipulator {
-		namespace modelutility {
+	namespace core {
+		namespace model {
 
-			/**
-			* Holds outcome of the autocalibration
-			*/
-			struct DrawingCalibration {
-				std::vector<repo::lib::RepoVector3D> horizontalCalibration3d;
-				std::vector<repo::lib::RepoVector2D> horizontalCalibration2d;
-				std::vector<float> verticalRange;
-				std::string units;
-			};
-
-			/**
-			* Holds complete information about an imported drawing at runtime
-			*/
-			struct DrawingImageInfo
+			class REPO_API_EXPORT RepoCalibration : public RepoBSON
 			{
-				std::string name; // The name of the original file (e.g. "Floor1.DWG")
-				std::vector<uint8_t> data; // The drawing in svg format
-				DrawingCalibration drawingCalibration;
+			public:
+
+				RepoCalibration() : RepoBSON() {}
+
+				RepoCalibration(RepoBSON bson) : RepoBSON(bson) {}
+
+				~RepoCalibration() {}
 			};
-		}
-	}
-}
+		}// end namespace model
+	} // end namespace core
+} // end namespace repo

--- a/bouncer/src/repo/core/model/bson/repo_bson_calibration.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_calibration.h
@@ -15,10 +15,6 @@
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-/**
-*  Assets BSON
-*/
-
 #pragma once
 
 #include "repo_bson.h"

--- a/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
@@ -757,44 +757,20 @@ RepoCalibration repo::core::model::RepoBSONFactory::makeRepoCalibration(
 	bsonBuilder.append(REPO_LABEL_REVISION, revisionId);
 	bsonBuilder.appendTimeStamp(REPO_LABEL_CREATEDAT);
 
+	if (horizontal2d.size() != horizontal3d.size() != 2)
+	{
+		throw std::runtime_error("Incomplete calibration vectors supplied to makeRepoCalibration");
+	}
+
 	RepoBSONBuilder horizontalBuilder;
-	if (horizontal3d.size() == 2)	{
-		std::vector<std::vector<float>>arrays;
-		std::vector<float> arr1;
-		arr1.push_back(horizontal3d[0].x);
-		arr1.push_back(horizontal3d[0].y);
-		arr1.push_back(horizontal3d[0].z);
-		arrays.push_back(arr1);
-
-		std::vector<float> arr2;
-		arr2.push_back(horizontal3d[1].x);
-		arr2.push_back(horizontal3d[1].y);
-		arr2.push_back(horizontal3d[1].z);
-		arrays.push_back(arr2);
-
-		horizontalBuilder.appendArray(REPO_LABEL_MODEL, arrays);
-	}
-	else {
-		repoError << "Incorrect amount of horizontal 3D vectors supplied to makeRepoCalibration" << std::endl;
-	}
-
-	if (horizontal2d.size() == 2)	{
-		std::vector<std::vector<float>>arrays;
-		std::vector<float> arr1;
-		arr1.push_back(horizontal2d[0].x);
-		arr1.push_back(horizontal2d[0].y);
-		arrays.push_back(arr1);
-
-		std::vector<float> arr2;
-		arr2.push_back(horizontal2d[1].x);
-		arr2.push_back(horizontal2d[1].y);
-		arrays.push_back(arr2);
-
-		horizontalBuilder.appendArray(REPO_LABEL_DRAWING, arrays);
-	}
-	else {
-		repoError << "Incorrect amount of horizontal 2D vectors supplied to makeRepoCalibration" << std::endl;
-	}
+	horizontalBuilder.appendArray< std::vector<float> >(REPO_LABEL_MODEL, {
+		horizontal3d[0].toStdVector(),
+		horizontal3d[1].toStdVector()
+	});
+	horizontalBuilder.appendArray< std::vector<float> >(REPO_LABEL_DRAWING, {
+		horizontal2d[0].toStdVector(),
+		horizontal2d[1].toStdVector()
+	});
 	bsonBuilder.append(REPO_LABEL_HORIZONTAL, horizontalBuilder.obj());
 
 	bsonBuilder.append(REPO_LABEL_UNITS, units);

--- a/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
@@ -748,7 +748,6 @@ RepoCalibration repo::core::model::RepoBSONFactory::makeRepoCalibration(
 	const repo::lib::RepoUUID& revisionId,
 	const std::vector<repo::lib::RepoVector3D>& horizontal3d,
 	const std::vector<repo::lib::RepoVector2D>& horizontal2d,
-	const std::vector<float>& verticalRange,
 	const std::string& units)
 {
 	RepoBSONBuilder bsonBuilder;
@@ -797,12 +796,6 @@ RepoCalibration repo::core::model::RepoBSONFactory::makeRepoCalibration(
 		repoError << "Incorrect amount of horizontal 2D vectors supplied to makeRepoCalibration" << std::endl;
 	}
 	bsonBuilder.append(REPO_LABEL_HORIZONTAL, horizontalBuilder.obj());
-
-	// (Note the vertical range is optional)
-
-	if (verticalRange.size() == 2)	{
-		bsonBuilder.appendArray(REPO_LABEL_VERTICALRANGE, verticalRange);
-	}
 
 	bsonBuilder.append(REPO_LABEL_UNITS, units);
 

--- a/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
@@ -742,6 +742,74 @@ RepoAssets RepoBSONFactory::makeRepoBundleAssets(
 	return RepoAssets(builder.obj());
 }
 
+RepoCalibration repo::core::model::RepoBSONFactory::makeRepoCalibration(
+	const repo::lib::RepoUUID& projectId,
+	const repo::lib::RepoUUID& drawingId,
+	const repo::lib::RepoUUID& revisionId,
+	const std::vector<repo::lib::RepoVector3D>& horizontal3d,
+	const std::vector<repo::lib::RepoVector2D>& horizontal2d,
+	const std::vector<float>& verticalRange,
+	const std::string& units)
+{
+	RepoBSONBuilder bsonBuilder;
+	bsonBuilder.append(REPO_LABEL_ID, repo::lib::RepoUUID::createUUID());
+	bsonBuilder.append(REPO_LABEL_PROJECT, projectId);
+	bsonBuilder.append(REPO_LABEL_DRAWING, drawingId);
+	bsonBuilder.append(REPO_LABEL_REVISION, revisionId);
+	bsonBuilder.appendTimeStamp(REPO_LABEL_CREATEDAT);
+
+	RepoBSONBuilder horizontalBuilder;
+	if (horizontal3d.size() == 2)	{
+		std::vector<std::vector<float>>arrays;
+		std::vector<float> arr1;
+		arr1.push_back(horizontal3d[0].x);
+		arr1.push_back(horizontal3d[0].y);
+		arr1.push_back(horizontal3d[0].z);
+		arrays.push_back(arr1);
+
+		std::vector<float> arr2;
+		arr2.push_back(horizontal3d[1].x);
+		arr2.push_back(horizontal3d[1].y);
+		arr2.push_back(horizontal3d[1].z);
+		arrays.push_back(arr2);
+
+		horizontalBuilder.appendArray(REPO_LABEL_MODEL, arrays);
+	}
+	else {
+		repoError << "Incorrect amount of horizontal 3D vectors supplied to makeRepoCalibration" << std::endl;
+	}
+
+	if (horizontal2d.size() == 2)	{
+		std::vector<std::vector<float>>arrays;
+		std::vector<float> arr1;
+		arr1.push_back(horizontal2d[0].x);
+		arr1.push_back(horizontal2d[0].y);
+		arrays.push_back(arr1);
+
+		std::vector<float> arr2;
+		arr2.push_back(horizontal2d[1].x);
+		arr2.push_back(horizontal2d[1].y);
+		arrays.push_back(arr2);
+
+		horizontalBuilder.appendArray(REPO_LABEL_DRAWING, arrays);
+	}
+	else {
+		repoError << "Incorrect amount of horizontal 2D vectors supplied to makeRepoCalibration" << std::endl;
+	}
+	bsonBuilder.append(REPO_LABEL_HORIZONTAL, horizontalBuilder.obj());
+
+	if (verticalRange.size() == 2)	{
+		bsonBuilder.appendArray(REPO_LABEL_VERTICALRANGE, verticalRange);
+	}
+	else {
+		repoError << "Incorrect amount of values for vertical range supplied to makeRepoCalibration" << std::endl;
+	}
+
+	bsonBuilder.append(REPO_LABEL_UNITS, units);
+
+	return RepoCalibration(bsonBuilder.obj());
+}
+
 ReferenceNode RepoBSONFactory::makeReferenceNode(
 	const std::string &database,
 	const std::string &project,

--- a/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson_factory.cpp
@@ -798,11 +798,10 @@ RepoCalibration repo::core::model::RepoBSONFactory::makeRepoCalibration(
 	}
 	bsonBuilder.append(REPO_LABEL_HORIZONTAL, horizontalBuilder.obj());
 
+	// (Note the vertical range is optional)
+
 	if (verticalRange.size() == 2)	{
 		bsonBuilder.appendArray(REPO_LABEL_VERTICALRANGE, verticalRange);
-	}
-	else {
-		repoError << "Incorrect amount of values for vertical range supplied to makeRepoCalibration" << std::endl;
 	}
 
 	bsonBuilder.append(REPO_LABEL_UNITS, units);

--- a/bouncer/src/repo/core/model/bson/repo_bson_factory.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_factory.h
@@ -29,6 +29,7 @@
 #include "repo_bson_task.h"
 #include "repo_bson_user.h"
 #include "repo_bson_assets.h"
+#include "repo_bson_calibration.h"
 #include "repo_node.h"
 #include "repo_node_camera.h"
 #include "repo_node_metadata.h"
@@ -161,6 +162,27 @@ namespace repo {
 					const std::vector<double>& offset,
 					const std::vector<std::string>& repoJsonFiles,
 					const std::vector<RepoSupermeshMetadata> metadata);
+
+				/**
+				* Create a Drawing Calibration BSON
+				* @param projectId uuid of the project
+				* @param drawingId uuid of the drawing
+				* @param revisionId uuid of the revision
+				* @param horizontal3d two reference points in the 3d space
+				* @param horizontal2d two reference points in the 2d space
+				* @param verticalRange two values marking the vertical range
+				* @param units the units used for the values.
+				* @return returns a RepoCalibration
+				*/
+				static RepoCalibration makeRepoCalibration(
+					const repo::lib::RepoUUID& projectId,
+					const repo::lib::RepoUUID& drawingId,
+					const repo::lib::RepoUUID& revisionId,
+					const std::vector<repo::lib::RepoVector3D>& horizontal3d,
+					const std::vector<repo::lib::RepoVector2D>& horizontal2d,
+					const std::vector<float>& verticalRange,
+					const std::string& units
+				);
 
 				/*
 				* -------------------- REPO NODES ------------------------

--- a/bouncer/src/repo/core/model/bson/repo_bson_factory.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_factory.h
@@ -170,7 +170,6 @@ namespace repo {
 				* @param revisionId uuid of the revision
 				* @param horizontal3d two reference points in the 3d space
 				* @param horizontal2d two reference points in the 2d space
-				* @param verticalRange two values marking the vertical range
 				* @param units the units used for the values.
 				* @return returns a RepoCalibration
 				*/

--- a/bouncer/src/repo/core/model/bson/repo_bson_factory.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_factory.h
@@ -180,7 +180,6 @@ namespace repo {
 					const repo::lib::RepoUUID& revisionId,
 					const std::vector<repo::lib::RepoVector3D>& horizontal3d,
 					const std::vector<repo::lib::RepoVector2D>& horizontal2d,
-					const std::vector<float>& verticalRange,
 					const std::string& units
 				);
 

--- a/bouncer/src/repo/core/model/repo_model_global.h
+++ b/bouncer/src/repo/core/model/repo_model_global.h
@@ -81,6 +81,15 @@
 // Vertex/triangle map propeties
 #define REPO_LABEL_MERGED_NODES     "merged_nodes"
 
+// Drawing calibration properties
+#define REPO_LABEL_DRAWING			"drawing"
+#define REPO_LABEL_REVISION			"revision"
+#define REPO_LABEL_CREATEDAT		"createdAt"
+#define REPO_LABEL_CREATEDBY		"createdBy"
+#define	REPO_LABEL_HORIZONTAL		"horizontal"
+#define REPO_LABEL_VERTICALRANGE	"verticalRange"
+#define	REPO_LABEL_UNITS			"units"
+
 #define REPO_COMMAND_UPDATE         "update"
 #define REPO_COMMAND_UPDATES        "updates"
 #define REPO_COMMAND_DELETE         "delete"
@@ -105,6 +114,7 @@
 #define REPO_COLLECTION_SEQUENCE        "sequences"
 #define REPO_COLLECTION_TASK            "activities"
 #define REPO_COLLECTION_DRAWINGS		"drawings.history"
+#define REPO_COLLECTION_CALIBRATIONS	"drawings.revisions.calibrations"
 
 #define REPO_COLLECTION_SETTINGS            "settings"
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor.cpp
@@ -67,3 +67,33 @@ std::unique_ptr<FileProcessor> FileProcessor::getFileProcessor(const std::string
 
 	return nullptr;
 }
+
+void FileProcessor::updateDrawingHorizontalCalibration(const OdGsView* pGsView, repo::manipulator::modelutility::DrawingCalibration& calibration)
+{
+	auto worldToDeviceMatrix = pGsView->worldToDeviceMatrix();
+
+	// Define the vectors in the drawing world coordinate system to resolve to
+	// SVG points.
+
+	OdGePoint3d a3d(0, 0, 0);
+	OdGePoint3d b3d(1, 0, 0);
+
+	// Calculate points in SVG space
+
+	OdGePoint3d a2d = worldToDeviceMatrix * a3d;
+	OdGePoint3d b2d = worldToDeviceMatrix * b3d;
+
+	// The SVG primitive coordinate system is the same one used by the frontend
+	// when interacting with the SVG.
+
+	calibration.horizontalCalibration2d.push_back(repo::lib::RepoVector2D(a2d.x, a2d.y));
+	calibration.horizontalCalibration2d.push_back(repo::lib::RepoVector2D(b2d.x, b2d.y));
+
+	// Transform the 3d vectors to the Repo coordinate system - the same
+	// transforms that would be applied to the 3D model, and which the Unity API
+	// operates in, which includes a conversion to a left-handed coordinate
+	// system.
+
+	calibration.horizontalCalibration3d.push_back(repo::lib::RepoVector3D(a3d.x, a3d.z, -a3d.y));
+	calibration.horizontalCalibration3d.push_back(repo::lib::RepoVector3D(b3d.x, b3d.z, -b3d.y));
+}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor.h
@@ -43,6 +43,10 @@ namespace repo {
 					GeometryCollector *collector;
 					modelutility::DrawingImageInfo* drawingCollector;
 					const ModelImportConfig& importConfig;
+
+					// Helper function to update the DrawingCalibration's horizontal calibration
+					// based on the MVP matrix of the view.
+					static void updateDrawingHorizontalCalibration(const OdGsView* view, modelutility::DrawingCalibration& calibration);
 				};
 			}
 		}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dgn.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dgn.cpp
@@ -367,9 +367,14 @@ void FileProcessorDgn::importDrawing(OdDgDatabasePtr pDb, const ODCOLORREF* pPal
 		OdGePoint3d aS = worldToDeviceMatrix * a;
 		OdGePoint3d bS = worldToDeviceMatrix * b;
 
-		// Convert to 2D by dropping z component (note: have not thought about it. Just conceptually).
-		repo::lib::RepoVector2D aS2d = repo::lib::RepoVector2D(aS.x, aS.y);
-		repo::lib::RepoVector2D bS2d = repo::lib::RepoVector2D(bS.x, bS.y);
+		// Get pixel density to apply it to SVG coordinates for converting from pixel to unit values
+		OdGePoint2d pixelDensity;
+		pGsView->getNumPixelsInUnitSquare(OdGePoint3d::kOrigin, pixelDensity, false);
+
+		// Convert to 2D by dropping z component and applying the density values
+		// (note: have not thought about it. Just conceptually).
+		repo::lib::RepoVector2D aS2d = repo::lib::RepoVector2D(aS.x / pixelDensity.x, aS.y / pixelDensity.y);
+		repo::lib::RepoVector2D bS2d = repo::lib::RepoVector2D(bS.x / pixelDensity.x, bS.y / pixelDensity.y);
 
 		// Convert 3d vectors from ODA format to 3d repo format
 		repo::lib::RepoVector3D a3d = repo::lib::RepoVector3D(a.x, a.y, a.z);

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dgn.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dgn.cpp
@@ -354,15 +354,6 @@ void FileProcessorDgn::importDrawing(OdDgDatabasePtr pDb, const ODCOLORREF* pPal
 		OdGePoint3d b(1, 0, 0);
 		OdGePoint3d c(0, 1, 0);
 
-		// The following vector contains the points in the SVG file corresponding
-		// to the 3D coordinates above. Add these to the appropriate schema when
-		// it is ready...
-
-		//std::vector<OdGePoint3d> points;
-		//points.push_back(worldToDeviceMatrix * a);
-		//points.push_back(worldToDeviceMatrix * b);
-		//points.push_back(worldToDeviceMatrix * c);
-
 		// Calculate points in SVG space
 		OdGePoint3d aS = worldToDeviceMatrix * a;
 		OdGePoint3d bS = worldToDeviceMatrix * b;
@@ -371,14 +362,14 @@ void FileProcessorDgn::importDrawing(OdDgDatabasePtr pDb, const ODCOLORREF* pPal
 		OdGePoint2d pixelDensity;
 		pGsView->getNumPixelsInUnitSquare(OdGePoint3d::kOrigin, pixelDensity, false);
 
-		// Convert to 2D by dropping z component and applying the density values
-		// (note: have not thought about it. Just conceptually).
+		// Flattening to 2D by dropping z component and applying the density values
 		repo::lib::RepoVector2D aS2d = repo::lib::RepoVector2D(aS.x / pixelDensity.x, aS.y / pixelDensity.y);
 		repo::lib::RepoVector2D bS2d = repo::lib::RepoVector2D(bS.x / pixelDensity.x, bS.y / pixelDensity.y);
 
 		// Convert 3d vectors from ODA format to 3d repo format
-		repo::lib::RepoVector3D a3d = repo::lib::RepoVector3D(a.x, a.y, a.z);
-		repo::lib::RepoVector3D b3d = repo::lib::RepoVector3D(b.x, b.y, b.z);
+		// (Note how z and y are switched to move from input z-up CS to Unity y-up CS)
+		repo::lib::RepoVector3D a3d = repo::lib::RepoVector3D(a.x, a.z, a.y);
+		repo::lib::RepoVector3D b3d = repo::lib::RepoVector3D(b.x, b.z, b.y);
 		
 		// Assemble calibration outcome
 		std::vector<repo::lib::RepoVector3D> horizontal3d;

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dgn.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dgn.cpp
@@ -340,26 +340,17 @@ void FileProcessorDgn::importDrawing(OdDgDatabasePtr pDb, const ODCOLORREF* pPal
 		// betweeen the SVG and world coordinate systems.
 		// The graphics system (Gs) view https://docs.opendesign.com/tv/gs_OdGsView.html
 		// is used to derive points that map between the WCS of the drawing and
-		// the svg file.
+		// the svg file for autocalibration.
 
 		const OdGsView* pGsView = pDeviceSvg->viewAt(0);
-		repo::manipulator::modelutility::DrawingCalibration calibration;
-		updateDrawingHorizontalCalibration(pGsView, calibration);
-
-		// Update the calibration vertical range
-		
-		calibration.verticalRange = { 0, 10 }; // TODO: how do I calculate that?
+		updateDrawingHorizontalCalibration(pGsView, drawingCollector->calibration);
 
 		// And set the calibration units
 
 		OdDgElementId elementActId = pDb->getActiveModelId();
 		OdDgModelPtr pModel = elementActId.safeOpenObject();
 		repo::manipulator::modelconvertor::ModelUnits units = determineModelUnits(pModel->getMasterUnit());
-		calibration.units = repo::manipulator::modelconvertor::toUnitsString(units);
-
-		// Pass calibration outcome to collector
-
-		drawingCollector->calibration = calibration;
+		drawingCollector->calibration.units = repo::manipulator::modelconvertor::toUnitsString(units);
 
 		// The call to update is what will create the svg in the memory stream
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
@@ -41,6 +41,8 @@
 
 using namespace repo::manipulator::modelconvertor::odaHelper;
 
+#define FLOOR_HEIGHT_M 2.4f
+
 class VectoriseDeviceDwg : public OdGsBaseVectorizeDevice
 {
 protected:
@@ -133,7 +135,7 @@ void FileProcessorDwg::importDrawing(OdDbDatabasePtr pDb)
 
 		pDbGiContext->setPlotGeneration(true);
 		pDbGiContext->setHatchAsPolygon(OdGiDefaultContext::kHatchPolygon);
-		dev->properties()->putAt(L"MinimalWidth", OdRxVariantValue(0.01));
+		dev->properties()->putAt(L"MinimalWidth", OdRxVariantValue(0.08));
 		pDbGiContext->setPaletteBackground(ODRGB(255, 255, 255));
 
 		OdDbBaseDatabasePEPtr pBaseDatabase(pDb);
@@ -157,109 +159,51 @@ void FileProcessorDwg::importDrawing(OdDbDatabasePtr pDb)
 
 		updateDrawingHorizontalCalibration(pGsView, calibration);
 
-
-		// TEST Vertical Calibration
-		/*
-		OdDbBlockTablePtr pTable = pDb->getBlockTableId().safeOpenObject(OdDb::kForRead);
-		OdDbBlockTableIteratorPtr blockRecordIter = pTable->newIterator();
-		
-
-		// Get extents with the matrix applied
-		OdGeExtents3d tableExtents;
-		OdResult tableResult = pTable->getGeomExtents(tableExtents);
-		if (tableResult == eOk) {
-			OdGePoint3d center = tableExtents.center();
-			OdGePoint3d minPoint = tableExtents.minPoint();
-			OdGePoint3d maxPoint = tableExtents.maxPoint();
-
-			std::cout << "Table Extent Fit Centre Point: " << center.x << " | " << center.y << " | " << center.z << std::endl;
-			std::cout << "Table Extent Fit Min Point: " << minPoint.x << " | " << minPoint.y << " | " << minPoint.z << std::endl;
-			std::cout << "Table Extent Fit Max Point: " << maxPoint.x << " | " << maxPoint.y << " | " << maxPoint.z << std::endl;
-		}
-		else {
-			std::cout << "No Extents for this. Error is: " << tableResult << std::endl;
-		}
-
-
-		for (; !blockRecordIter->done(); blockRecordIter->step()) {
-			OdDbBlockTableRecordPtr record = blockRecordIter->getRecordId().safeOpenObject();
-			
-			// Dump Record information
-			std::cout << "New Record:" << std::endl;
-			std::cout << record->getName() << std::endl;
-
-			// Block Type
-			std::cout << "Is Anonymous: " << (record->isAnonymous() ? "True" : "False") << std::endl;
-			std::cout << "Is from external ref: " << (record->isFromExternalReference() ? "True" : "False") << std::endl;
-			std::cout << "Is Layout: " << (record->isLayout() ? "True" : "False") << std::endl;
-
-			
-			// Get origin
-			OdGePoint3d blockOrigin = record->origin();
-			std::cout << "Origin: " << blockOrigin.x << " | " << blockOrigin.y << " | " << blockOrigin.z << " | " << std::endl;
-
-			// Get raw extents
-			OdGeExtents3d blockExtents;
-			OdResult result = record->getGeomExtents(blockExtents);
-			// record->geomExtentsBestFit takes a matrix? Can we do that with our post-view CS?
-			if (result == eOk) {
-				OdGePoint3d center = blockExtents.center();
-				OdGePoint3d minPoint = blockExtents.minPoint();
-				OdGePoint3d maxPoint = blockExtents.maxPoint();
-
-				std::cout << "Extent Centre Point: " << center.x << " | " << center.y << " | " << center.z << std::endl;
-				std::cout << "Extent Min Point: " << minPoint.x << " | " << minPoint.y << " | " << minPoint.z << std::endl;
-				std::cout << "Extent Max Point: " << maxPoint.x << " | " << maxPoint.y << " | " << maxPoint.z << std::endl;
-			}
-			else {
-				std::cout << "No Extents for this. Error is: " << result << std::endl;
-			}
-
-			// Get extents with the matrix applied
-			OdGeExtents3d blockExtentsFit;
-			result = record->geomExtentsBestFit(blockExtents, worldToDeviceMatrix);
-			// record->geomExtentsBestFit takes a matrix? Can we do that with our post-view CS?
-			if (result == eOk) {
-				OdGePoint3d center = blockExtentsFit.center();
-				OdGePoint3d minPoint = blockExtentsFit.minPoint();
-				OdGePoint3d maxPoint = blockExtentsFit.maxPoint();
-
-				std::cout << "Extent Fit Centre Point: " << center.x << " | " << center.y << " | " << center.z << std::endl;
-				std::cout << "Extent Fit Min Point: " << minPoint.x << " | " << minPoint.y << " | " << minPoint.z << std::endl;
-				std::cout << "Extent Fit Max Point: " << maxPoint.x << " | " << maxPoint.y << " | " << maxPoint.z << std::endl;
-			}
-			else {
-				std::cout << "No Extents for this. Error is: " << result << std::endl;
-			}
-			
-			//// Iterate over entities
-			//std::cout << "Printing Entities:" << std::endl;
-			//OdDbObjectIteratorPtr entityIter = record->newIterator();
-
-			//for (; !entityIter->done(); entityIter->step()) {
-			//	OdDbEntityPtr entity = entityIter->entity();
-			//	printf("ObjectID: %lx\n", entity->objectId());
-			//	
-			//	std::cout << "Class name: " << (entity->isA()).c_str());
-			//}
-
-		}
-
-		*/
-		// END TEST Vertical Calibration
-
-
-		calibration.verticalRange = { 0, 10 }; // TODO: how do I calculate that?
-
-		// Update drawing calibration units and assign to the collector
+		// Collect the units (we may also need these for the vertical calibration)
 
 		repo::manipulator::modelconvertor::ModelUnits units = determineModelUnits(pDb->getINSUNITS());
 		calibration.units = repo::manipulator::modelconvertor::toUnitsString(units);
 
+		// Get the vertical calibration by checking the geometry extents of all
+		// entities (visual elements).
+
+		double zmin = DBL_MAX;
+		double zmax = DBL_MIN;
+
+		OdDbBlockTablePtr pTable = pDb->getBlockTableId().safeOpenObject(OdDb::kForRead);
+		OdDbBlockTableIteratorPtr blockRecordIter = pTable->newIterator();
+		for (; !blockRecordIter->done(); blockRecordIter->step()) {
+			
+			OdDbBlockTableRecordPtr record = blockRecordIter->getRecordId().safeOpenObject();
+
+			OdDbObjectIteratorPtr entityIter = record->newIterator();
+			for (; !entityIter->done(); entityIter->step()) {
+				OdDbEntityPtr entity = entityIter->entity();
+
+				OdGeExtents3d extents;
+				if (entity->drawable()->getGeomExtents(extents) == eOk) {
+					zmin = std::min(zmin, extents.minPoint().z);
+					zmax = std::max(zmax, extents.maxPoint().z);
+				}
+			}
+		}
+
+		// If the drawing is all on one plane, then just take this plane.
+		// Otherwise try and guess the range based on the default floor height.
+
+		if (zmin == zmax)
+		{
+			calibration.verticalRange = { (float)zmin, scaleFactorFromMetres(units) * FLOOR_HEIGHT_M };
+		}
+		else
+		{
+			calibration.verticalRange = { (float)zmin, (float)zmax };
+		}
+
 		drawingCollector->calibration = calibration;
 
 		// Render the SVG
-		
+
 		pHelperDevice->update();
 
 		// Copy the SVG contents into a string

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
@@ -176,9 +176,14 @@ void FileProcessorDwg::importDrawing(OdDbDatabasePtr pDb)
 		OdGePoint3d aS = worldToDeviceMatrix * a;
 		OdGePoint3d bS = worldToDeviceMatrix * b;
 
-		// Convert to 2D by dropping z component (note: have not thought about it. Just conceptually).
-		repo::lib::RepoVector2D aS2d = repo::lib::RepoVector2D(aS.x, aS.y);
-		repo::lib::RepoVector2D bS2d = repo::lib::RepoVector2D(bS.x, bS.y);
+		// Get pixel density to apply it to SVG coordinates for converting from pixel to unit values
+		OdGePoint2d pixelDensity;
+		pGsView->getNumPixelsInUnitSquare(OdGePoint3d::kOrigin, pixelDensity, false);
+
+		// Convert to 2D by dropping z component and applying the density values
+		// (note: have not thought about it. Just conceptually).
+		repo::lib::RepoVector2D aS2d = repo::lib::RepoVector2D(aS.x / pixelDensity.x, aS.y / pixelDensity.y);
+		repo::lib::RepoVector2D bS2d = repo::lib::RepoVector2D(bS.x / pixelDensity.x, bS.y / pixelDensity.y);
 
 		// Convert 3d vectors from ODA format to 3d repo format
 		repo::lib::RepoVector3D a3d = repo::lib::RepoVector3D(a.x, a.y, a.z);

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
@@ -136,6 +136,7 @@ void FileProcessorDwg::importDrawing(OdDbDatabasePtr pDb)
 		pDbGiContext->setPlotGeneration(true);
 		pDbGiContext->setHatchAsPolygon(OdGiDefaultContext::kHatchPolygon);
 		dev->properties()->putAt(L"MinimalWidth", OdRxVariantValue(0.08));
+		dev->properties()->putAt(L"UseHLR", OdRxVariantValue(true));
 		pDbGiContext->setPaletteBackground(ODRGB(255, 255, 255));
 
 		OdDbBaseDatabasePEPtr pBaseDatabase(pDb);

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
@@ -163,15 +163,6 @@ void FileProcessorDwg::importDrawing(OdDbDatabasePtr pDb)
 		OdGePoint3d b(1, 0, 0);
 		OdGePoint3d c(0, 1, 0);
 
-		// The following vector contains the points in the SVG file corresponding
-		// to the 3D coordinates above. Add these to the appropriate schema when
-		// it is ready...
-
-		//std::vector<OdGePoint3d> points;
-		//points.push_back(worldToDeviceMatrix * a);
-		//points.push_back(worldToDeviceMatrix * b);
-		//points.push_back(worldToDeviceMatrix * c);
-
 		// Calculate points in SVG space
 		OdGePoint3d aS = worldToDeviceMatrix * a;
 		OdGePoint3d bS = worldToDeviceMatrix * b;
@@ -180,14 +171,14 @@ void FileProcessorDwg::importDrawing(OdDbDatabasePtr pDb)
 		OdGePoint2d pixelDensity;
 		pGsView->getNumPixelsInUnitSquare(OdGePoint3d::kOrigin, pixelDensity, false);
 
-		// Convert to 2D by dropping z component and applying the density values
-		// (note: have not thought about it. Just conceptually).
+		// Flattening to 2D by dropping z component and applying the density values
 		repo::lib::RepoVector2D aS2d = repo::lib::RepoVector2D(aS.x / pixelDensity.x, aS.y / pixelDensity.y);
 		repo::lib::RepoVector2D bS2d = repo::lib::RepoVector2D(bS.x / pixelDensity.x, bS.y / pixelDensity.y);
 
 		// Convert 3d vectors from ODA format to 3d repo format
-		repo::lib::RepoVector3D a3d = repo::lib::RepoVector3D(a.x, a.y, a.z);
-		repo::lib::RepoVector3D b3d = repo::lib::RepoVector3D(b.x, b.y, b.z);
+		// (Note how z and y are switched to move from input z-up CS to Unity y-up CS)
+		repo::lib::RepoVector3D a3d = repo::lib::RepoVector3D(a.x, a.z, a.y);
+		repo::lib::RepoVector3D b3d = repo::lib::RepoVector3D(b.x, b.z, b.y);
 
 		// Assemble calibration outcome
 		std::vector<repo::lib::RepoVector3D> horizontal3d;

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
@@ -41,8 +41,6 @@
 
 using namespace repo::manipulator::modelconvertor::odaHelper;
 
-#define FLOOR_HEIGHT_M 2.4f
-
 class VectoriseDeviceDwg : public OdGsBaseVectorizeDevice
 {
 protected:

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.h
@@ -47,6 +47,11 @@ namespace repo {
 
 				protected:
 					OdStaticRxObject<RepoDwgServices> svcs;
+
+				private:
+					void importModel(OdDbDatabasePtr pDb);
+					void importDrawing(OdDbDatabasePtr pDb);
+					ModelUnits determineModelUnits(const OdDb::UnitsValue units);
 				};
 			}
 		}

--- a/bouncer/src/repo/manipulator/modelutility/repo_drawing.h
+++ b/bouncer/src/repo/manipulator/modelutility/repo_drawing.h
@@ -42,7 +42,7 @@ namespace repo {
 			{
 				std::string name; // The name of the original file (e.g. "Floor1.DWG")
 				std::vector<uint8_t> data; // The drawing in svg format
-				DrawingCalibration drawingCalibration;
+				DrawingCalibration calibration;
 			};
 		}
 	}

--- a/bouncer/src/repo/manipulator/modelutility/repo_drawing.h
+++ b/bouncer/src/repo/manipulator/modelutility/repo_drawing.h
@@ -31,7 +31,6 @@ namespace repo {
 			struct DrawingCalibration {
 				std::vector<repo::lib::RepoVector3D> horizontalCalibration3d;
 				std::vector<repo::lib::RepoVector2D> horizontalCalibration2d;
-				std::vector<float> verticalRange;
 				std::string units;
 			};
 

--- a/bouncer/src/repo/manipulator/modelutility/repo_drawing_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_drawing_manager.cpp
@@ -73,7 +73,7 @@ uint8_t DrawingManager::commitImage(
 	}
 
 	// Retreive and process calibration
-	auto calibration = drawing.drawingCalibration;
+	auto calibration = drawing.calibration;
 
 	auto calibrationBSON = repo::core::model::RepoBSONFactory::makeRepoCalibration(
 		revision.getProject(),

--- a/bouncer/src/repo/manipulator/modelutility/repo_drawing_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_drawing_manager.cpp
@@ -60,7 +60,7 @@ uint8_t DrawingManager::commitImage(
 		drawing.data,
 		metadata.obj()
 	);
-	
+
 	auto updated = revision.cloneAndAddImage(drawingRefNodeId);
 
 	std::string error;
@@ -91,7 +91,6 @@ uint8_t DrawingManager::commitImage(
 		repoError << "Error committing calibration: " << error;
 		return REPOERR_UPLOAD_FAILED;
 	}
-
 
 	return REPOERR_OK;
 }

--- a/bouncer/src/repo/manipulator/modelutility/repo_drawing_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_drawing_manager.cpp
@@ -81,7 +81,6 @@ uint8_t DrawingManager::commitImage(
 		revId,
 		calibration.horizontalCalibration3d,
 		calibration.horizontalCalibration2d,
-		calibration.verticalRange,
 		calibration.units
 	);
 

--- a/bouncer/src/repo/manipulator/modelutility/repo_drawing_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_drawing_manager.cpp
@@ -18,6 +18,7 @@
 
 #include "../../core/model/bson/repo_bson_builder.h"
 #include "../../core/model/bson/repo_bson_ref.h"
+#include "../../core/model/bson/repo_bson_factory.h"
 #include "../../error_codes.h"
 
 using namespace repo::manipulator::modelutility;
@@ -45,11 +46,12 @@ uint8_t DrawingManager::commitImage(
 	auto name = drawing.name.substr(0, drawing.name.size() - 3) + "svg"; // The name should be the drawing's original name with an updated extension
 
 	repo::core::model::RepoBSONBuilder metadata;
+	auto revId = revision.getUniqueID();
 	metadata.append(REPO_NODE_LABEL_NAME, name);
 	metadata.append(REPO_LABEL_MEDIA_TYPE, REPO_MEDIA_TYPE_SVG);
 	metadata.append(REPO_LABEL_PROJECT, revision.getProject());
 	metadata.append(REPO_LABEL_MODEL, revision.getModel());
-	metadata.append(REPO_NODE_REVISION_ID, revision.getUniqueID());
+	metadata.append(REPO_NODE_REVISION_ID, revId);
 
 	fileManager->uploadFileAndCommit(
 		teamspace,
@@ -58,7 +60,7 @@ uint8_t DrawingManager::commitImage(
 		drawing.data,
 		metadata.obj()
 	);
-
+	
 	auto updated = revision.cloneAndAddImage(drawingRefNodeId);
 
 	std::string error;
@@ -69,6 +71,28 @@ uint8_t DrawingManager::commitImage(
 		repoError << "Error committing drawing: " << error;
 		return REPOERR_UPLOAD_FAILED;
 	}
+
+	// Retreive and process calibration
+	auto calibration = drawing.drawingCalibration;
+
+	auto calibrationBSON = repo::core::model::RepoBSONFactory::makeRepoCalibration(
+		revision.getProject(),
+		revision.getModel(),
+		revId,
+		calibration.horizontalCalibration3d,
+		calibration.horizontalCalibration2d,
+		calibration.verticalRange,
+		calibration.units
+	);
+
+	handler->insertDocument(teamspace, REPO_COLLECTION_CALIBRATIONS, calibrationBSON, error);
+
+	if (error.size())
+	{
+		repoError << "Error committing calibration: " << error;
+		return REPOERR_UPLOAD_FAILED;
+	}
+
 
 	return REPOERR_OK;
 }

--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -97,7 +97,7 @@ int32_t performOperation(
 			errCode = REPOERR_UNKNOWN_ERR;
 		}
 	}
-	if (command.command == cmdProcessDrawing)
+	else if (command.command == cmdProcessDrawing)
 	{
 		try {
 			errCode = processDrawing(controller, token, command);


### PR DESCRIPTION
This fixes #695

#### Description
This PR extends the DGN and DWG importers to write the horizontal calibration of a drawing when processDrawing is called. The calibration is always written and contains a pair of a pair of vectors from which the calibration between SVG coordinates and Repo/Project coordinates can be recovered.

This PR also increase the minimum line with from 0.01 to 0.08.

The line that does this for further tweaks is:

```dev->properties()->putAt(L"MinimalWidth", OdRxVariantValue(0.08));```

