### PR TITLE
ISSUE #705 fixes drawing import issues on local

### DIFF
--- a/tools/bouncer_worker/src/lib/messageDecoder.js
+++ b/tools/bouncer_worker/src/lib/messageDecoder.js
@@ -31,6 +31,10 @@ const replaceSharedDirPlaceHolder = (command) => {
 		const data = fs.readFileSync(cmdArr[2], 'utf8');
 		const result = data.replace(tagToReplace, config.rabbitmq.sharedDir);
 		fs.writeFileSync(cmdArr[2], result, 'utf8');
+	} else if (cmdArr[0] === 'processDrawing') {
+		const data = fs.readFileSync(cmdArr[1], 'utf8');
+		const result = data.replace(tagToReplace, config.rabbitmq.sharedDir);
+		fs.writeFileSync(cmdArr[1], result, 'utf8');
 	}
 	return cmd;
 };


### PR DESCRIPTION
This fixes #705
#### Description
Convert placeholders to shareDir path on importParams for drawings

this requires https://github.com/3drepo/3drepo.io/issues/5177

#### Test cases
cross platform drawing import should now work

