### PR TITLE
ISSUE #703 dont explode fonts into shapes

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_dwg.cpp
@@ -140,6 +140,8 @@ void FileProcessorDwg::importDrawing(OdDbDatabasePtr pDb)
 		dev->properties()->putAt(L"MinimalWidth", OdRxVariantValue(0.08));
 		dev->properties()->putAt(L"UseHLR", OdRxVariantValue(true));
 		dev->properties()->putAt(L"ColorPolicy", OdRxVariantValue((OdInt32)3)); // kDarken
+		dev->properties()->putAt(L"ExplodeShxTexts", OdRxVariantValue(false));
+
 		pDbGiContext->setPaletteBackground(ODRGB(255, 255, 255));
 
 		OdDbBaseDatabasePEPtr pBaseDatabase(pDb);


### PR DESCRIPTION
This fixes #708 

#### Description
This PR tells the svg exporter not to explode SHX fonts. SHX fonts have been superseded by TTF fonts in Autodesk products so are unlikely to be encountered.

If they are encountered, this will force the exporter to draw a <text> element without a font-face definition, rather than try to draw  the font as geometry. 

Practically speaking, this PR is just for completeness and should not have much effect so long as we have a complete set of font packages installed in the bouncer containers, which is out of scope of this issue.

