### PR TITLE
ISSUE #648  path to 3drepobouncerClient executable can have spaces

### DIFF
--- a/tools/bouncer_worker/src/lib/runCommand.js
+++ b/tools/bouncer_worker/src/lib/runCommand.js
@@ -12,8 +12,8 @@ const run = (
 	{ codesAsSuccess = [], verbose = true, logLabel },
 	processInformation,
 ) => new Promise((resolve, reject) => {
-	if (verbose) logger.info(`Executing command: ${exe} ${params.join(' ')}`, logLabel);
-	const cmdExec = spawn(exe, params, { shell: true });
+	if (verbose) logger.info(`Executing command: "${exe}" ${params.join(' ')}`, logLabel);
+	const cmdExec = spawn(`"${exe}"`, params, { shell: true });
 	if (processInformation) processMonitor.startMonitor(processInformation);
 	let isTimeout = false;
 	let hasTerminated = false;


### PR DESCRIPTION
This fixes #648 

#### Description
This PR adds quotations around the exe passed to `spawn`, which allows the name in the config to include spaces. On Linux these are not necessary, but do no harm.