### PR TITLE
ISSUE #723 Mongo database handler properly handles connection string

### DIFF
--- a/bouncer/src/repo/core/handler/repo_database_handler_mongo.h
+++ b/bouncer/src/repo/core/handler/repo_database_handler_mongo.h
@@ -80,7 +80,7 @@ namespace repo {
 				* @param password password of the user (optional)
 				*/
 				MongoDatabaseHandler(
-					const std::string& dbAddress,
+					const std::string& connectionString,
 					const std::string& username,
 					const std::string& password,
 					const ConnectionOptions& options = ConnectionOptions()

--- a/cmake_modules/FindMongoCXXDriver.cmake
+++ b/cmake_modules/FindMongoCXXDriver.cmake
@@ -34,6 +34,7 @@ if(DEFINED ENV{MONGO_ROOT})
 	find_library(MONGO_CXX_DRIVER
 		NAMES
 			mongocxx
+			mongocxx-v_noabi-rhs-x64-v142-md
 		PATHS
 			${MONGO_CXX_DRIVER_ROOT}/lib
 	)
@@ -41,6 +42,7 @@ if(DEFINED ENV{MONGO_ROOT})
 	find_library(MONGO_CXX_BSON
 		NAMES
 			bsoncxx
+			bsoncxx-v_noabi-rhs-x64-v142-md
 		PATHS
 			${MONGO_CXX_DRIVER_ROOT}/lib
 	)

--- a/test/src/unit/repo/core/handler/ut_repo_database_handler_mongo.cpp
+++ b/test/src/unit/repo/core/handler/ut_repo_database_handler_mongo.cpp
@@ -129,6 +129,38 @@ TEST(MongoDatabaseHandlerTest, GetHandler)
 		EXPECT_TRUE(handler);
 		EXPECT_THROW(handler->testConnection(), std::exception);
 	}
+
+	// This case tests when we provide a connection string, including existing
+	// options. The test should succeed.
+	{
+		// This connection string includes an option, but expects the username and
+		// password to be provided.
+		std::string connectionString = "mongodb://" + REPO_GTEST_DBADDRESS + ":" + std::to_string(REPO_GTEST_DBPORT) + "/?authSource=admin";
+		auto handler = MongoDatabaseHandler::getHandler(
+			connectionString,
+			REPO_GTEST_DBUSER,
+			REPO_GTEST_DBPW,
+			options
+		);
+		EXPECT_TRUE(handler);
+		EXPECT_NO_THROW(handler->testConnection());
+	}
+
+	// This case tests when we provide a connection string, including existing
+	// options. The test should succeed.
+	{
+		// This connection string includes the username and password,
+		// so those in the config should be ignored.
+		std::string connectionString = "mongodb://" + REPO_GTEST_DBUSER + ":" + REPO_GTEST_DBPW + "@" + REPO_GTEST_DBADDRESS + ":" + "27017" + "/?authSource=admin";
+		auto handler = MongoDatabaseHandler::getHandler(
+			connectionString,
+			"invalidUser",
+			"invalidPassword",
+			options
+		);
+		EXPECT_TRUE(handler);
+		EXPECT_NO_THROW(handler->testConnection());
+	}
 }
 
 // Equality operator for use by GetAllFromCollectionTailable


### PR DESCRIPTION
This fixes #723

#### Description
1. Correctly adds the credentials from the config to the Mongo connection string, if it does not already have any.
2. Masks the credentials, no matter where they came from, when printing the URI to the log in an exception.

Additionally adds unit tests to cover these use cases that were missing before.

regex could be used to mask the username and password, but has an ambiguous feature set (e.g. the positive lookahead operator is not supported) & from comments also possible compiler differences, so given how simple the task is it seemed more robust to do it 'explicitly' with `find`.

#### Test cases
<!-- Test cases that this pull request expect to pass -->

