### PR TITLE
ISSUE #737 - Redefine elastic config validation

### DIFF
--- a/tools/bouncer_worker/config_example.json
+++ b/tools/bouncer_worker/config_example.json
@@ -32,10 +32,10 @@
 	},
 	"defaultStorage": "db",
 	"elastic": {
-		"enabled"   : false,
-		"cloudId"   : "cloudhost:xxx",
-		"cloudAuth" : "username:password",
-		"namespace" : ""
+		"cloud"      : { "id" : "ElasticCloudId:abc12345" },
+		"auth"       : { "apiKey" : "*******************" },
+		"namespace"  : "example",
+		"maxRetries" : 5
 	},
 	"processMonitoring" : {
 		"enabled" : false,

--- a/tools/bouncer_worker/src/lib/config.js
+++ b/tools/bouncer_worker/src/lib/config.js
@@ -57,12 +57,10 @@ const bouncer = object({
 });
 
 const elastic = object({
-	cloud: object({id: string()}).default(undefined),
-	auth: object({apiKey: string()}).default(undefined),
-	namespace: string(),
-	reload_connections: boolean(),
-	maxRetries: number(),
-	request_timeout: number(),
+	cloud: object({id: string().required()}),
+	auth: object({apiKey: string().required()}),
+	namespace: string().required(),
+	maxRetries: number().default(5),
 }).default(undefined);
 
 const logging = object({

--- a/tools/bouncer_worker/src/lib/config.js
+++ b/tools/bouncer_worker/src/lib/config.js
@@ -56,14 +56,22 @@ const bouncer = object({
 	log_dir: string(),
 });
 
+const elasticCloud = object({
+	id: string(),
+}).default(undefined);
+
+const elasticAuth = object({
+	apiKey: string(),
+}).default(undefined);
+
 const elastic = object({
-	cloud: envars,
-	auth: envars,
+	cloud: elasticCloud,
+	auth: elasticAuth,
 	namespace: string(),
 	reload_connections: boolean(),
 	maxRetries: number(),
 	request_timeout: number(),
-});
+}).default(undefined);
 
 const logging = object({
 	taskLogDir: string(),

--- a/tools/bouncer_worker/src/lib/config.js
+++ b/tools/bouncer_worker/src/lib/config.js
@@ -56,17 +56,9 @@ const bouncer = object({
 	log_dir: string(),
 });
 
-const elasticCloud = object({
-	id: string(),
-}).default(undefined);
-
-const elasticAuth = object({
-	apiKey: string(),
-}).default(undefined);
-
 const elastic = object({
-	cloud: elasticCloud,
-	auth: elasticAuth,
+	cloud: object({id: string()}).default(undefined),
+	auth: object({apiKey: string()}).default(undefined),
 	namespace: string(),
 	reload_connections: boolean(),
 	maxRetries: number(),

--- a/tools/bouncer_worker/src/lib/config.js
+++ b/tools/bouncer_worker/src/lib/config.js
@@ -57,8 +57,12 @@ const bouncer = object({
 });
 
 const elastic = object({
-	cloud: object({id: string().required()}),
-	auth: object({apiKey: string().required()}),
+	cloud: object({
+		id: string().required(),
+	}),
+	auth: object({
+		apiKey: string().required(),
+	}),
 	namespace: string().required(),
 	maxRetries: number().default(5),
 }).default(undefined);


### PR DESCRIPTION
This fixes #737

#### Description
- Validation wasn't allowing `elastic` to be undefined in the config as it recycled `envars` definition
- bouncer_worker can now be run without `elastic` being defined

#### Test cases
- Run bouncer_worker with `elastic` in config
- Run bouncer_worker without `elastic` in config
