### PR TITLE
Issue 752

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/ifcHelper/repo_ifc_helper_parser.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/ifcHelper/repo_ifc_helper_parser.cpp
@@ -38,7 +38,9 @@ void convertTreeToNodes(
 	if (tree.createNode) {
 		std::vector<repo::lib::RepoUUID> metaParents;
 
-		if (!tree.isIfcSpace) {
+		bool absorbTrans = tree.isIfcSpace && !tree.hasTransChildren;
+
+		if (!absorbTrans) {
 			auto transNode = new repo::core::model::TransformationNode(repo::core::model::RepoBSONFactory::makeTransformationNode(tree.transformation, tree.name, parents));
 			childrenParents = { transNode->getSharedID() };
 			metaParents = childrenParents;
@@ -48,7 +50,7 @@ void convertTreeToNodes(
 		if (meshes.find(tree.guid) != meshes.end()) {
 			for (auto &mesh : meshes[tree.guid]) {
 				mesh->addParents(childrenParents); // In the IFC importer, meshes are already created per-instance and so are updated in-place
-				if (tree.meshTakeName && mesh->getName().empty() || tree.isIfcSpace) {
+				if (tree.hasTransChildren && mesh->getName().empty() || absorbTrans) {
 					mesh->changeName(tree.name);
 					metaParents.push_back(mesh->getSharedID());
 				}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/ifcHelper/repo_ifc_helper_parser.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/ifcHelper/repo_ifc_helper_parser.cpp
@@ -38,7 +38,7 @@ void convertTreeToNodes(
 	if (tree.createNode) {
 		std::vector<repo::lib::RepoUUID> metaParents;
 
-		if (!tree.absorbTrans) {
+		if (!tree.isIfcSpace) {
 			auto transNode = new repo::core::model::TransformationNode(repo::core::model::RepoBSONFactory::makeTransformationNode(tree.transformation, tree.name, parents));
 			childrenParents = { transNode->getSharedID() };
 			metaParents = childrenParents;
@@ -48,7 +48,7 @@ void convertTreeToNodes(
 		if (meshes.find(tree.guid) != meshes.end()) {
 			for (auto &mesh : meshes[tree.guid]) {
 				mesh->addParents(childrenParents); // In the IFC importer, meshes are already created per-instance and so are updated in-place
-				if (tree.absorbTrans || tree.meshTakeName && mesh->getName().empty()) {
+				if (tree.meshTakeName && mesh->getName().empty() || tree.isIfcSpace) {
 					mesh->changeName(tree.name);
 					metaParents.push_back(mesh->getSharedID());
 				}

--- a/ifcUtils/repo_ifc_utils_globals.h
+++ b/ifcUtils/repo_ifc_utils_globals.h
@@ -65,5 +65,5 @@ struct TransNode {
 	std::vector<TransNode> children;
 	bool createNode = false;
 	bool meshTakeName = false;
-	bool absorbTrans = false;
+	bool isIfcSpace = false;
 };

--- a/ifcUtils/repo_ifc_utils_globals.h
+++ b/ifcUtils/repo_ifc_utils_globals.h
@@ -64,6 +64,6 @@ struct TransNode {
 	std::unordered_map<std::string, repo::lib::RepoVariant> meta;
 	std::vector<TransNode> children;
 	bool createNode = false;
-	bool meshTakeName = false;
+	bool hasTransChildren = false;
 	bool isIfcSpace = false;
 };

--- a/ifcUtils/repo_ifc_utils_tree_parser.cpp
+++ b/ifcUtils/repo_ifc_utils_tree_parser.cpp
@@ -209,7 +209,7 @@ TransNode repo::ifcUtility::SCHEMA_NS::TreeParser::createTransformationsRecursiv
 		transNode.meta.insert(elementInfo.begin(), elementInfo.end());
 		transNode.meta.insert(locationInfo.begin(), locationInfo.end());
 		transNode.meshTakeName = hasTransChildren;
-		transNode.absorbTrans = !hasTransChildren;
+		transNode.isIfcSpace = isIFCSpace;
 	}
 	else
 	{

--- a/ifcUtils/repo_ifc_utils_tree_parser.cpp
+++ b/ifcUtils/repo_ifc_utils_tree_parser.cpp
@@ -208,7 +208,7 @@ TransNode repo::ifcUtility::SCHEMA_NS::TreeParser::createTransformationsRecursiv
 		transNode.meta[REPO_LABEL_IFC_TYPE] = element->data().type()->name();
 		transNode.meta.insert(elementInfo.begin(), elementInfo.end());
 		transNode.meta.insert(locationInfo.begin(), locationInfo.end());
-		transNode.meshTakeName = hasTransChildren;
+		transNode.hasTransChildren = hasTransChildren;
 		transNode.isIfcSpace = isIFCSpace;
 	}
 	else


### PR DESCRIPTION
This fixes #752

#### Description
This PR makes the IFC importer more conservative about which transforms it absorbs. This is to avoid accidentally creating multiple tree entries for entities with multiple unnamed submeshes.

This fix will be superseded by the IFC importer upgrade in 5.18.

#### Test cases
<!-- Test cases that this pull request expect to pass -->

