### PR TITLE
ISSUE #755 fix for appendElements using view that may be moved

### DIFF
--- a/bouncer/src/repo/core/model/bson/repo_bson_builder.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson_builder.cpp
@@ -196,6 +196,7 @@ void RepoBSONBuilder::appendElementsUnique(RepoBSON bson)
 		if (view.find(element.key()) == view.end()) {
 			key_view(element.key());
 			append(element.get_value());
+			view = core::view_document(); // If we change the document, we must update the view as the underlying memory may have moved
 		}
 	}
 }


### PR DESCRIPTION
This fixes #755

#### Description
Recreate the view of the builder that is being appended to if it changes - this is because a view is non-owning and so the builder may move the memory inside the loop.

#### Test cases
<!-- Test cases that this pull request expect to pass -->

