### PR TITLE
ISSUE #773 support for the world orientation in nwd partitions

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/helper_functions.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/helper_functions.cpp
@@ -78,3 +78,13 @@ repo::lib::RepoVector3D64 repo::manipulator::modelconvertor::odaHelper::toRepoVe
 {
 	return repo::lib::RepoVector3D64(p.x, p.y, p.z);
 }
+
+repo::lib::RepoVector3D64 repo::manipulator::modelconvertor::odaHelper::toRepoVector(const OdGeVector3d& p)
+{
+	return repo::lib::RepoVector3D64(p.x, p.y, p.z);
+}
+
+repo::lib::RepoBounds repo::manipulator::modelconvertor::odaHelper::toRepoBounds(const OdGeExtents3d& b)
+{
+	return *(repo::lib::RepoBounds*)(&b);
+}

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/helper_functions.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/helper_functions.h
@@ -30,6 +30,7 @@
 #include <Database/Enums/BmViewTypeEnum.h>
 
 #include "repo/lib/datastructure/repo_structs.h"
+#include "repo/lib/datastructure/repo_bounds.h"
 
 namespace repo {
 	namespace manipulator {
@@ -72,6 +73,8 @@ namespace repo {
 				repo::lib::RepoVector3D64 calcNormal(repo::lib::RepoVector3D64 p1, repo::lib::RepoVector3D64 p2, repo::lib::RepoVector3D64 p3);
 
 				repo::lib::RepoVector3D64 toRepoVector(const OdGePoint3d& p);
+				repo::lib::RepoVector3D64 toRepoVector(const OdGeVector3d& p);
+				repo::lib::RepoBounds toRepoBounds(const OdGeExtents3d& b);
 			}
 		}
 	}

--- a/test/src/unit/repo_test_matchers.h
+++ b/test/src/unit/repo_test_matchers.h
@@ -29,8 +29,8 @@
  * error but is far less noticable, so the tolerance is higher.
  */
 
-#define POSITION_TOLERANCE 0.0000001f
-#define DIRECTION_TOLERANCE 0.00001f
+#define POSITION_TOLERANCE 0.0000001
+#define DIRECTION_TOLERANCE 0.00001
 
 namespace testing {
 
@@ -56,24 +56,30 @@ namespace testing {
 	* matcher to compare vectors having undergone transformations such as
 	* rotations or scales.
 	*/
-	MATCHER_P(VectorNear, a, "")
+
+	MATCHER_P2(VectorNear, a, tolerance, "")
 	{
-		if (!::testing::ExplainMatchResult(::testing::FloatNear(arg.x, POSITION_TOLERANCE), a.x, result_listener))
+		if (!::testing::ExplainMatchResult(::testing::NanSensitiveDoubleNear((double)arg.x, tolerance), (double)a.x, result_listener))
 		{
 			*result_listener << " in the z axis.";
 			return false;
 		}
-		if (!::testing::ExplainMatchResult(::testing::FloatNear(arg.y, POSITION_TOLERANCE), a.y, result_listener))
+		if (!::testing::ExplainMatchResult(::testing::NanSensitiveDoubleNear((double)arg.y, tolerance), (double)a.y, result_listener))
 		{
 			*result_listener << " in the y axis.";
 			return false;
 		}
-		if (!::testing::ExplainMatchResult(::testing::FloatNear(arg.z, POSITION_TOLERANCE), a.z, result_listener))
+		if (!::testing::ExplainMatchResult(::testing::NanSensitiveDoubleNear((double)arg.z, tolerance), (double)a.z, result_listener))
 		{
 			*result_listener << " in the z axis.";
 			return false;
 		}
 		return true;
+	}
+
+	MATCHER_P(VectorNear, a, "")
+	{
+		return ::testing::ExplainMatchResult(VectorNear(a, POSITION_TOLERANCE), arg, result_listener);
 	}
 
 	MATCHER_P(VectorGe, a, "")
@@ -158,20 +164,20 @@ namespace testing {
 		return boost::apply_visitor(repo::lib::DuplicationVisitor(), arg, repo::lib::RepoVariant(s));
 	}
 
-	static bool compareBounds(const repo::lib::RepoBounds& a, const repo::lib::RepoBounds& b, double tolerance)
+	static bool compareBounds(const repo::lib::RepoBounds& a, const repo::lib::RepoBounds& b, double tolerance, testing::MatchResultListener* listener)
 	{
-		return
-			abs(a.min().x - b.min().x) < tolerance &&
-			abs(a.min().y - b.min().y) < tolerance &&
-			abs(a.min().z - b.min().z) < tolerance &&
-			abs(a.max().x - b.max().x) < tolerance &&
-			abs(a.max().y - b.max().y) < tolerance &&
-			abs(a.max().z - b.max().z) < tolerance;
+		if (abs(a.min().x - b.min().x) > tolerance) { *listener << "Bounds Min x exceeds tolerance."; return false; }
+		if (abs(a.min().y - b.min().y) > tolerance) { *listener << "Bounds Min y exceeds tolerance."; return false; }
+		if (abs(a.min().z - b.min().z) > tolerance) { *listener << "Bounds Min z exceeds tolerance."; return false; }
+		if (abs(a.max().x - b.max().x) > tolerance) { *listener << "Bounds Max x exceeds tolerance."; return false; }
+		if (abs(a.max().y - b.max().y) > tolerance) { *listener << "Bounds Max y exceeds tolerance."; return false; }
+		if (abs(a.max().z - b.max().z) > tolerance) { *listener << "Bounds Max z exceeds tolerance."; return false; }
+		return true;
 	}
 
 	MATCHER_P2(BoundsAre, bounds, tolerance, "")
 	{
-		return compareBounds(arg, bounds, tolerance);
+		return compareBounds(arg, bounds, tolerance, result_listener);
 	}
 
 	MATCHER_P2(UnorderedBoundsAre, elements, tolerance, "")
@@ -180,7 +186,7 @@ namespace testing {
 
 		for (auto& r : arg) {
 			for (auto i = 0; i < bounds.size(); i++) {
-				if (compareBounds(r, bounds[i], tolerance)) {
+				if (compareBounds(r, bounds[i], tolerance, result_listener)) {
 					bounds.erase(bounds.begin() + i);
 					break;
 				}


### PR DESCRIPTION
This fixes #773 - support for World Orientation of Navis partitions

#### Description
This PR adds a stage to the Navis importer that checks for the Up and North vectors of OdNwPartitions, and uses them to create a top-level transformation that puts geometry into the correct project coordinate conventions (X-East, Y-North, Z-Elevation) on import.

In doing this, the PR also adjusts slightly how the file is processed, first enumerating the Model entries, then their root elements (Nodes). This pattern (that a database has multiple models, each with its own branch, instead of just one branch with ModelItems being child nodes) is now [the one recommended by ODA](https://docs.opendesign.com/bimnv/bimnv_extract_nwd_nwc_data.html), and from 26.xx will be the only one supported.

Models (and the OdNwPartitions at their roots) correspond to the files/links in a Navis federation, so in theory can have their own World Transforms and Units and Transforms. In practice, we will only ever have one, because when saving NWDs, Navis bakes the federation under a new node that represents the NWD itself. Still, for completeness the PR is written such that multiple models could be supported.

Finally, unit tests are introduced for new functionality, and some unit tests have been accordingly updated to be more generic and verbose.

#### Acceptance Criteria
<!-- Copy and paste the acceptance criteria here from the product issue and verify that they all passed 
e.g.
- [x] As a Commenter+, I want to be able to delete images in image preview before I leave the comment.
- [x] As a Commenter+, I want to be able to delete images after I leave the comment.

If you cannot find Acceptance criteria for your issue, check with a member of the QA team
-->

