### PR TITLE
Issue 776 - Changed default view settings for Revit

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
@@ -271,6 +271,13 @@ void setupViewOverrides(OdBmDBViewPtr pView)
 
 	ids.push_back(db->getObjectId(OdBm::BuiltInCategory::OST_SunStudy));
 
+	// We also want to hide topography contours
+
+	ids.push_back(db->getObjectId(OdBm::BuiltInCategory::OST_TopographyContours));
+	ids.push_back(db->getObjectId(OdBm::BuiltInCategory::OST_SecondaryTopographyContours));
+	ids.push_back(db->getObjectId(OdBm::BuiltInCategory::OST_ToposolidContours));
+	ids.push_back(db->getObjectId(OdBm::BuiltInCategory::OST_ToposolidSecondaryContours));
+
 	pView->setCategoryHidden(ids, true);
 
 	pView->setActiveWorkPlaneVisibility(false);

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
@@ -292,6 +292,10 @@ OdBmDBView3dPtr createDefault3DView(OdBmDatabasePtr pDb, std::string style)
 	pDBView3d = OdBmDBView3d::createObject();
 	pDb->addElement(pDBView3d); // element must be added to DB before setDefaultOrigin, createDefaultDrawingAndViewport, setPerspective
 
+	if (style.empty()) {
+		style = std::string("shaded");
+	}
+
 	if (style == "wireframe") {
 		pDBView3d->setDisplayStyle(OdBm::ViewDisplayStyle::Wireframe);
 	}
@@ -301,8 +305,11 @@ OdBmDBView3dPtr createDefault3DView(OdBmDatabasePtr pDb, std::string style)
 	else if (style == "shaded") {
 		pDBView3d->setDisplayStyle(OdBm::ViewDisplayStyle::Shaded);
 	}
-	else {
+	else if (style == "shadedwithedges"){
 		pDBView3d->setDisplayStyle(OdBm::ViewDisplayStyle::ShadedWithEdges);
+	}
+	else {
+		throw repo::lib::RepoSceneProcessingException("Style: " + style + " is not a valid style. Must be wireframe, hiddenline, shadedwithedges or shaded");
 	}
 
 	pDBView3d->setDetailLevel(OdBm::ViewDetailLevel::Fine);

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -409,10 +409,10 @@ TEST(ODAModelImport, DefaultViewVisibility)
 	// Transparency should work as well
 	EXPECT_THAT(door.hasTransparency(), IsTrue());
 
-	// Should include 3d geometry and lines
+	// Should include 3d geometry without edges
 	auto floorNode = utils.findNodeByMetadata("Element ID", "2928847");
 	EXPECT_THAT(floorNode.getMeshes(repo::core::model::MeshNode::Primitive::TRIANGLES), Not(IsEmpty()));
-	EXPECT_THAT(floorNode.getMeshes(repo::core::model::MeshNode::Primitive::LINES), Not(IsEmpty()));
+	EXPECT_THAT(floorNode.getMeshes(repo::core::model::MeshNode::Primitive::LINES), IsEmpty());
 }
 
 TEST(ODAModelImport, NamedView)

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -468,8 +468,7 @@ TEST(ODAModelImport, DefaultViewDisplayOptions)
 			"RevitNamedView"
 		);
 		config.targetUnits = ModelUnits::MILLIMETRES;
-
-		// Default (nothing or a string that doesn't match the others) is shaded with edges
+		config.viewStyle = "shadedwithedges";
 
 		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport(getDataPath("sample2025.rvt"), config));
 
@@ -485,13 +484,29 @@ TEST(ODAModelImport, DefaultViewDisplayOptions)
 			"RevitNamedView"
 		);
 		config.targetUnits = ModelUnits::MILLIMETRES;
-		config.viewStyle = "shaded";
+
+		// Default (empty string) is shaded
 
 		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport(getDataPath("sample2025.rvt"), config));
 
 		EXPECT_THAT(scene.findNodeByMetadata("Element ID", "307098").getMeshes(repo::core::model::MeshNode::Primitive::TRIANGLES).size(), Gt(0)); // Two textures and a flat surface
 		EXPECT_THAT(scene.findNodeByMetadata("Element ID", "307098").getMeshes(repo::core::model::MeshNode::Primitive::LINES).size(), Eq(0));
 		EXPECT_THAT(scene.findNodeByMetadata("Element ID", "307098").hasTextures(), IsTrue());
+	}
+
+	{
+		ModelImportConfig config(
+			repo::lib::RepoUUID::createUUID(),
+			TESTDB,
+			"RevitNamedView"
+		);
+		config.targetUnits = ModelUnits::MILLIMETRES;
+		config.viewStyle = "notsupported";
+
+		EXPECT_THROW({
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport(getDataPath("sample2025.rvt"), config));
+		},
+		repo::lib::RepoSceneProcessingException);
 	}
 
 	{


### PR DESCRIPTION
This fixes #776 

#### Description
This PR makes adjustment to the default view settings for Revit.

The default import view is now `shaded`, instead of `shadedwithedges`, and contour lines are always hidden along with other annotations.

Additionally, only an empty string is now accepted as the view style; invalid strings will throw an exception. There is no new error code for this, because only .io should be setting this parameter via a dropdown.

#### Acceptance Criteria
<!-- Copy and paste the acceptance criteria here from the product issue and verify that they all passed 
e.g.
- [x] As a Commenter+, I want to be able to delete images in image preview before I leave the comment.
- [x] As a Commenter+, I want to be able to delete images after I leave the comment.

If you cannot find Acceptance criteria for your issue, check with a member of the QA team
-->

