### PR TITLE
ISSUE #784 All metadata nodes should be children of their mesh siblings

### DIFF
--- a/bouncer/src/repo/core/handler/database/repo_query.h
+++ b/bouncer/src/repo/core/handler/database/repo_query.h
@@ -22,6 +22,7 @@
 #include "repo_query_fwd.h"
 
 #include <vector>
+#include <set>
 #include <string>
 #include <memory>
 #include <variant>
@@ -149,6 +150,12 @@ namespace repo {
 					public:
 						AddParent(const repo::lib::RepoUUID& uniqueId, std::vector<repo::lib::RepoUUID> parentIds) :
 							uniqueId(uniqueId),
+							parentIds(parentIds.begin(), parentIds.end())
+						{
+						}
+
+						AddParent(const repo::lib::RepoUUID& uniqueId, std::set<repo::lib::RepoUUID> parentIds) :
+							uniqueId(uniqueId),
 							parentIds(parentIds)
 						{
 						}
@@ -160,7 +167,7 @@ namespace repo {
 						}
 
 						repo::lib::RepoUUID uniqueId;
-						std::vector<repo::lib::RepoUUID> parentIds;
+						std::set<repo::lib::RepoUUID> parentIds;
 					};
 
 					/*

--- a/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
+++ b/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
@@ -239,12 +239,12 @@ struct MongoUpdateVisitor
 
 		if (u.parentIds.size() == 1)
 		{
-			operation.append(REPO_NODE_LABEL_PARENTS, u.parentIds[0]);
+			operation.append(REPO_NODE_LABEL_PARENTS, *u.parentIds.begin());
 		}
 		else
 		{
 			repo::core::model::RepoBSONBuilder array;
-			array.appendArray("$each", u.parentIds);
+			array.appendIteratable("$each", u.parentIds.begin(), u.parentIds.end());
 			operation.append(REPO_NODE_LABEL_PARENTS, array.obj());
 		}
 

--- a/bouncer/src/repo/core/model/bson/repo_bson_builder.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_builder.h
@@ -90,6 +90,21 @@ namespace repo {
 					append(vec);
 				}
 
+				template <class T>
+				void appendIteratable(
+					const std::string& label,
+					T begin,
+					T end
+				)
+				{
+					core::key_owned(label);
+					core::open_array();
+					for (auto it = begin; it != end; it++) {
+						append(*it);
+					}
+					core::close_array();
+				}
+
 				template<class T>
 				void append(
 					const std::string& label,

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_manager.h
@@ -44,6 +44,11 @@ namespace repo {
 					const std::string &file,
 					const repo::manipulator::modelconvertor::ModelImportConfig &config
 				) const;
+
+				void connectMetadataNodes(repo::core::model::RepoScene* scene,
+					std::shared_ptr<repo::core::handler::AbstractDatabaseHandler> handler) const;
+
+				void connectMetadataNodes(repo::core::model::RepoScene* scene) const;
 			};
 		} //namespace modelconvertor
 	} //namespace manipulator

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_builder.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_builder.cpp
@@ -332,7 +332,7 @@ void RepoSceneBuilder::addParent(repo::lib::RepoUUID nodeUniqueId, repo::lib::Re
 
 	if (parentUpdates.find(nodeUniqueId) != parentUpdates.end())
 	{
-		parentUpdates[nodeUniqueId]->parentIds.push_back(parentSharedId);
+		parentUpdates[nodeUniqueId]->parentIds.insert(parentSharedId);
 	}
 	else
 	{

--- a/test/src/unit/CMakeLists.txt
+++ b/test/src/unit/CMakeLists.txt
@@ -7,6 +7,7 @@
 add_subdirectory(repo)
 set(TEST_SOURCES
 	${TEST_SOURCES}
+	${CMAKE_CURRENT_SOURCE_DIR}/repo_test_common_tests.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_test_database_info.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_test_matchers.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_test_mesh_utils.cpp
@@ -16,6 +17,7 @@ set(TEST_SOURCES
 
 set(TEST_HEADERS
 	${TEST_HEADERS}
+	${CMAKE_CURRENT_SOURCE_DIR}/repo_test_common_tests.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_test_database_info.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_test_fileservice_info.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_test_matchers.h

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -131,7 +131,7 @@ TEST_F(NwdTestSuite, Sample2025NWDTree)
 	nodes = utils.findTransformationNodesByName("Wall-Ext_102Bwk-75Ins-100LBlk-12P");
 	EXPECT_THAT(nodes.size(), Eq(1));
 
-	auto children = nodes[0].getChildren();
+	auto children = nodes[0].getChildren({repo::core::model::NodeType::MESH, repo::core::model::NodeType::TRANSFORMATION});
 	EXPECT_THAT(children.size(), Eq(6));
 
 	for (auto n : children) {
@@ -576,3 +576,21 @@ TEST(ODAModelImport, DefaultViewDisplayOptions)
 		EXPECT_THAT(scene.findNodeByMetadata("Element ID", "307098").hasTextures(), IsFalse());
 	}
 }
+
+/*
+TEST(ODAModelImport, MetadataParents)
+{
+	// All metadata nodes must also have their sibling meshnodes as parents,
+	// in order to resolve ids by mesh node in the frontend
+
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("Sample2025NWD", getDataPath(nwdModel2025)));
+		for (auto& metadata : scene.getMetadataNodes())
+		{
+			auto meshParents = metadata.getParents({ repo::core::model::NodeType::MESH });
+			auto meshSiblings = metadata.getSiblings({ repo::core::model::NodeType::TRANSFORMATION }, { repo::core::model::NodeType::MESH });
+			EXPECT_THAT(meshSiblings, UnorderedElementsAreArray(meshParents));
+		}
+	}
+}
+*/

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -26,6 +26,7 @@
 #include "../../../../../repo_test_database_info.h"
 #include "../../../../../repo_test_scene_utils.h"
 #include "../../../../../repo_test_matchers.h"
+#include "../../../../../repo_test_common_tests.h"
 #include "repo/manipulator/modelconvertor/import/odaHelper/file_processor_nwd.h"
 
 using namespace repo::manipulator::modelconvertor;
@@ -577,20 +578,51 @@ TEST(ODAModelImport, DefaultViewDisplayOptions)
 	}
 }
 
-/*
-TEST(ODAModelImport, MetadataParents)
+TEST_F(NwdTestSuite, MetadataParentsNWD)
 {
 	// All metadata nodes must also have their sibling meshnodes as parents,
 	// in order to resolve ids by mesh node in the frontend
 
 	{
-		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("Sample2025NWD", getDataPath(nwdModel2025)));
-		for (auto& metadata : scene.getMetadataNodes())
-		{
-			auto meshParents = metadata.getParents({ repo::core::model::NodeType::MESH });
-			auto meshSiblings = metadata.getSiblings({ repo::core::model::NodeType::TRANSFORMATION }, { repo::core::model::NodeType::MESH });
-			EXPECT_THAT(meshSiblings, UnorderedElementsAreArray(meshParents));
-		}
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MetadataParentsNWD", getDataPath(nwdModel2025)));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MetadataParentsNWD", getDataPath("groupsAndReferences.nwc")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MetadataParentsNWD", getDataPath("orientedColumns.nwd")));
+		common::checkMetadataInheritence(scene);
 	}
 }
-*/
+
+TEST(ODAModelImport, MetadataParents)
+{
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MetadataParentsRVT", getDataPath("sample2025.rvt")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MetadataParentsRVT", getDataPath("MetaTest2.rvt")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MetadataParentsDWG", getDataPath("nestedBlocks.dwg")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MetadataParentsDWG", getDataPath("colouredBoxes.dwg")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MetadataParentsDGN", getDataPath("sample.dgn")));
+		common::checkMetadataInheritence(scene);
+	}
+}

--- a/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_3drepo.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_3drepo.cpp
@@ -27,6 +27,7 @@
 #include "../../../../repo_test_scene_utils.h"
 #include "../../../../repo_test_mesh_utils.h"
 #include "../../../../repo_test_matchers.h"
+#include "../../../../repo_test_common_tests.h"
 
 using namespace repo::manipulator::modelconvertor;
 using namespace testing;
@@ -276,8 +277,6 @@ TEST(RepoModelImport, EmptyTransforms)
 	}
 }
 
-#pragma optimize("", off)
-
 TEST(RepoModelImport, TransformHierarchy1)
 {
 	/*
@@ -399,4 +398,29 @@ TEST(RepoModelImport, Colours)
 	EXPECT_THAT(scene.findLeafNode("[287]").getColours(), ElementsAre(repo::lib::repo_color4d_t(0.949019611, 0.403921604, 0.133333296, 1)));
 	EXPECT_THAT(scene.findLeafNode("[28B]").getColours(), ElementsAre(repo::lib::repo_color4d_t(0.898039222, 0.909803927, 0.470588207, 1)));
 	EXPECT_THAT(scene.findLeafNode("[28F]").getColours(), ElementsAre(repo::lib::repo_color4d_t(0.368627489, 0.403921604, 0.686274529, 1)));
+}
+
+TEST(RepoModelImport, MetadataParents)
+{
+	uint8_t errCode;
+
+	{
+		SceneUtils scene(RepoModelImportUtils::ImportBIMFile(getDataPath("RepoModelImport/columns_navis.bim"), errCode));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(RepoModelImportUtils::ImportBIMFile(getDataPath("RepoModelImport/blockHierarchy.civils.bim004.bim"), errCode));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(RepoModelImportUtils::ImportBIMFile(getDataPath("RepoModelImport/columns_revit.bim"), errCode));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(RepoModelImportUtils::ImportBIMFile(getDataPath("RepoModelImport/metadata.bim004.bim"), errCode));
+		common::checkMetadataInheritence(scene);
+	}
 }

--- a/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_ifc.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_ifc.cpp
@@ -25,6 +25,7 @@
 #include "../../../../repo_test_database_info.h"
 #include "../../../../repo_test_scene_utils.h"
 #include "../../../../repo_test_matchers.h"
+#include "../../../../repo_test_common_tests.h"
 
 using namespace repo::manipulator::modelconvertor;
 using namespace repo::core::model;
@@ -814,4 +815,39 @@ TEST(IFCModelImport, Ifc4x3_Add2)
 	auto scene = IfcModelImportUtils::ModelImportManagerImport("VersionTests", getDataPath(ifc4x3_add2Model));
 	SceneUtils utils(scene);
 	EXPECT_TRUE(utils.isPopulated());
+}
+
+TEST(IFCModelImport, MetadataParents)
+{
+	uint8_t errCode;
+
+	{
+		SceneUtils scene(IfcModelImportUtils::ModelImportManagerImport("IfcMetadataTests", getDataPath("duct.ifc")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(IfcModelImportUtils::ModelImportManagerImport("IfcMetadataTests", getDataPath("duplex.ifc")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(IfcModelImportUtils::ModelImportManagerImport("IfcMetadataTests", getDataPath("ifc4x3.ifc")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(IfcModelImportUtils::ModelImportManagerImport("IfcMetadataTests", getDataPath("ifc2x3.ifc")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(IfcModelImportUtils::ModelImportManagerImport("IfcMetadataTests", getDataPath("simpleHouse1.ifc")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(IfcModelImportUtils::ModelImportManagerImport("IfcMetadataTests", getDataPath("Wall.ifc")));
+		common::checkMetadataInheritence(scene);
+	}
 }

--- a/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_synchro.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_synchro.cpp
@@ -17,9 +17,33 @@
 
 #include <gtest/gtest.h>
 #include <repo/manipulator/modelconvertor/import/repo_model_import_synchro.h>
+#include <repo/manipulator/modelconvertor/import/repo_model_import_manager.h>
 #include "../../../../repo_test_database_info.h"
+#include "../../../../repo_test_utils.h"
+#include "../../../../repo_test_scene_utils.h"
+#include "../../../../repo_test_common_tests.h"
 
 using namespace repo::manipulator::modelconvertor;
+using namespace testing;
+
+repo::core::model::RepoScene* ModelImportManagerImport(std::string db, std::string path)
+{
+	auto config = ModelImportConfig();
+	config.databaseName = "SynchroTestDb";
+	config.revisionId = repo::lib::RepoUUID::createUUID();
+	config.projectName = db;
+
+	auto handler = getHandler();
+
+	uint8_t err;
+	std::string msg;
+
+	ModelImportManager manager;
+	auto scene = manager.ImportFromFile(path, config, handler, err);
+	scene->commit(handler.get(), handler->getFileManager().get(), msg, "testuser", "", "", config.getRevisionId());
+
+	return scene;
+}
 
 TEST(SynchroModelImport, ConstructorTest)
 {
@@ -40,4 +64,20 @@ TEST(SynchroModelImport, ImportModel)
 	auto scene = import.importModel(getDataPath(synchroVersion6_4), handler, errCode);	
 	EXPECT_EQ(0, errCode);
 	ASSERT_TRUE(scene);
+}
+
+TEST(SynchroModelImport, MetadataParents)
+{
+	uint8_t errCode;
+
+	{
+		SceneUtils scene(ModelImportManagerImport("SynchroMetadataTests", getDataPath("synchro6_4.spm")));
+		common::checkMetadataInheritence(scene);
+	}
+
+	{
+		SceneUtils scene(ModelImportManagerImport("SynchroMetadataTests", getDataPath("synchro6_5.spm")));
+		common::checkMetadataInheritence(scene);
+	}
+
 }

--- a/test/src/unit/repo_test_common_tests.cpp
+++ b/test/src/unit/repo_test_common_tests.cpp
@@ -1,0 +1,46 @@
+/**
+*  Copyright (C) 2025 3D Repo Ltd
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Affero General Public License as
+*  published by the Free Software Foundation, either version 3 of the
+*  License, or (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Affero General Public License for more details.
+*
+*  You should have received a copy of the GNU Affero General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "repo_test_common_tests.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest-matchers.h>
+
+using namespace testing;
+using namespace testing::common;
+
+void testing::common::checkMetadataInheritence(SceneUtils& scene)
+{
+	for (auto& metadata : scene.getMetadataNodes())
+	{
+		auto meshParents = metadata.getParents({ repo::core::model::NodeType::MESH });
+
+		for (auto& parent : metadata.getParents({ repo::core::model::NodeType::TRANSFORMATION }))
+		{
+			// When a metadata node is a child of transformation leaf node (i.e.
+			// with only unnamed meshes), it should also be a child of those mesh
+			// nodes.
+
+			if (parent.isLeaf())
+			{
+				auto meshSiblings = parent.getMeshes();
+				EXPECT_THAT(meshSiblings, IsSubsetOf(meshParents));
+			}
+		}
+	}
+}

--- a/test/src/unit/repo_test_common_tests.h
+++ b/test/src/unit/repo_test_common_tests.h
@@ -1,0 +1,26 @@
+/**
+*  Copyright (C) 2025 3D Repo Ltd
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Affero General Public License as
+*  published by the Free Software Foundation, either version 3 of the
+*  License, or (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Affero General Public License for more details.
+*
+*  You should have received a copy of the GNU Affero General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "repo_test_scene_utils.h"
+
+namespace testing {
+	namespace common {
+		void checkMetadataInheritence(testing::SceneUtils& scene);
+	}
+}

--- a/test/src/unit/repo_test_scene_utils.cpp
+++ b/test/src/unit/repo_test_scene_utils.cpp
@@ -348,6 +348,7 @@ SceneUtils::NodeInfo SceneUtils::NodeInfo::getParent() const
 std::vector<SceneUtils::NodeInfo> SceneUtils::NodeInfo::getParents(SceneUtils::Filter filter) const
 {
 	auto parents = scene->getParentNodes(node, filter);
+	return parents;
 }
 
 std::string SceneUtils::NodeInfo::getPath() const

--- a/test/src/unit/repo_test_scene_utils.cpp
+++ b/test/src/unit/repo_test_scene_utils.cpp
@@ -119,25 +119,27 @@ SceneUtils::NodeInfo SceneUtils::findLeafNode(std::string name)
 	return nodes[0];
 }
 
-std::vector<SceneUtils::NodeInfo> SceneUtils::getChildNodes(repo::core::model::RepoNode* node, bool ignoreMeta)
+std::vector<SceneUtils::NodeInfo> SceneUtils::getChildNodes(repo::core::model::RepoNode* node, Filter filter)
 {
 	std::vector<NodeInfo> nodes;
 	for (auto& n : scene->getChildrenAsNodes(repo::core::model::RepoScene::GraphType::DEFAULT, node->getSharedID()))
 	{
-		if (ignoreMeta && n->getTypeAsEnum() == repo::core::model::NodeType::METADATA) {
-			continue;
+		if (filter.size() == 0 || std::find(filter.begin(), filter.end(), n->getTypeAsEnum()) != filter.end()) {
+			nodes.push_back(getNodeInfo(n));
 		}
-		nodes.push_back(getNodeInfo(n));
 	}
 	return nodes;
 }
 
-std::vector<SceneUtils::NodeInfo> SceneUtils::getParentNodes(repo::core::model::RepoNode* node)
+std::vector<SceneUtils::NodeInfo> SceneUtils::getParentNodes(repo::core::model::RepoNode* node, Filter filter)
 {
 	std::vector<NodeInfo> nodes;
-	for (auto& n : scene->getParentNodesFiltered(repo::core::model::RepoScene::GraphType::DEFAULT, node, repo::core::model::NodeType::TRANSFORMATION))
-	{
-		nodes.push_back(getNodeInfo(n));
+	for (auto& pid : node->getParentIDs()) {
+		auto p = scene->getNodeBySharedID(repo::core::model::RepoScene::GraphType::DEFAULT, pid);
+		if(filter.size() == 0 || std::find(filter.begin(), filter.end(), p->getTypeAsEnum()) != filter.end())
+		{
+			nodes.push_back(getNodeInfo(p));
+		}
 	}
 	return nodes;
 }
@@ -180,11 +182,9 @@ std::vector<SceneUtils::NodeInfo> SceneUtils::NodeInfo::getMeshes(repo::core::mo
 std::vector<SceneUtils::NodeInfo> SceneUtils::NodeInfo::getMeshes()
 {
 	std::vector<SceneUtils::NodeInfo> meshNodes;
-	for (auto& c : scene->getChildNodes(node, true))
+	for (auto& c : scene->getChildNodes(node, { repo::core::model::NodeType::MESH }))
 	{
-		if (dynamic_cast<MeshNode*>(c.node)) {
-			meshNodes.push_back(c);
-		}
+		meshNodes.push_back(c);
 	}
 	if (dynamic_cast<MeshNode*>(this->node)) {
 		meshNodes.push_back(*this);
@@ -239,10 +239,8 @@ std::vector<SceneUtils::NodeInfo> SceneUtils::NodeInfo::getTextures()
 	}
 	
 	for (auto m : meshes) {
-		for (auto c : scene->getChildNodes(m, true)) {
-			if (auto material = dynamic_cast<MaterialNode*>(c.node)) {
-				materials.push_back(material);
-			}
+		for (auto c : scene->getChildNodes(m, { repo::core::model::NodeType::MATERIAL })) {
+			materials.push_back(dynamic_cast<MaterialNode*>(c.node));
 		}
 	}
 	
@@ -251,14 +249,25 @@ std::vector<SceneUtils::NodeInfo> SceneUtils::NodeInfo::getTextures()
 	}
 	
 	for (auto m : materials) {
-		for (auto& c : scene->getChildNodes(m, true)) {
-			if (dynamic_cast<TextureNode*>(c.node)) {
-				textures.push_back(c);
-			}
+		for (auto& c : scene->getChildNodes(m, { repo::core::model::NodeType::TEXTURE })) {
+			textures.push_back(c);
 		}
 	}
 
 	return textures;
+}
+
+std::vector<SceneUtils::NodeInfo> SceneUtils::NodeInfo::getSiblings(Filter p, Filter s)
+{
+	std::vector<SceneUtils::NodeInfo> siblings;
+	for (auto& p : this->getParents(p)) {
+		for (auto& c : scene->getChildNodes(p.node, s)) {
+			if (c != *this) {
+				siblings.push_back(c);
+			}
+		}
+	}
+	return siblings;
 }
 
 std::vector<SceneUtils::NodeInfo> SceneUtils::getMeshes()
@@ -270,26 +279,31 @@ std::vector<SceneUtils::NodeInfo> SceneUtils::getMeshes()
 	return meshes;
 }
 
+std::vector<SceneUtils::NodeInfo> SceneUtils::getMetadataNodes()
+{
+	std::vector<SceneUtils::NodeInfo> metadata;
+	for (auto n : scene->getAllMetadata(repo::core::model::RepoScene::GraphType::DEFAULT)) {
+		metadata.push_back(getNodeInfo(n));
+	}
+	return metadata;
+}
+
 std::unordered_map<std::string, repo::lib::RepoVariant> SceneUtils::NodeInfo::getMetadata()
 {
 	std::unordered_map<std::string, repo::lib::RepoVariant> metadata;
-	for (auto c : scene->getChildNodes(node, false))
+	for (auto c : scene->getChildNodes(node, { repo::core::model::NodeType::METADATA }))
 	{
-		if (dynamic_cast<MetadataNode*>(c.node)) {
-			auto m = dynamic_cast<MetadataNode*>(c.node)->getAllMetadata();
-			metadata.insert(m.begin(), m.end());
-		}
+		auto m = dynamic_cast<MetadataNode*>(c.node)->getAllMetadata();
+		metadata.insert(m.begin(), m.end());
 	}
 	return metadata;
 }
 
 repo::lib::repo_material_t SceneUtils::NodeInfo::getMaterial()
 {
-	for (auto& c : scene->getChildNodes(node, true))
+	for (auto& c : scene->getChildNodes(node, {repo::core::model::NodeType::MATERIAL}))
 	{
-		if (dynamic_cast<MaterialNode*>(c.node)) {
-			return dynamic_cast<MaterialNode*>(c.node)->getMaterialStruct();
-		}
+		return dynamic_cast<MaterialNode*>(c.node)->getMaterialStruct();
 	}
 	throw std::runtime_error("Node does not have a material");
 }
@@ -316,7 +330,7 @@ bool SceneUtils::NodeInfo::hasTransparency()
 std::vector<std::string> SceneUtils::NodeInfo::getChildNames()
 {
 	std::vector<std::string> names;
-	for (auto c : scene->getChildNodes(node, true))
+	for (auto c : scene->getChildNodes(node, { repo::core::model::NodeType::MESH, repo::core::model::NodeType::TRANSFORMATION }))
 	{
 		if (!c.node->getName().empty()) {
 			names.push_back(c.node->getName());
@@ -327,13 +341,18 @@ std::vector<std::string> SceneUtils::NodeInfo::getChildNames()
 
 SceneUtils::NodeInfo SceneUtils::NodeInfo::getParent() const
 {
-	auto parents = scene->getParentNodes(node);
+	auto parents = scene->getParentNodes(node, { repo::core::model::NodeType::TRANSFORMATION });
 	return parents[0];
+}
+
+std::vector<SceneUtils::NodeInfo> SceneUtils::NodeInfo::getParents(SceneUtils::Filter filter) const
+{
+	auto parents = scene->getParentNodes(node, filter);
 }
 
 std::string SceneUtils::NodeInfo::getPath() const
 {
-	auto parents = scene->getParentNodes(node);
+	auto parents = scene->getParentNodes(node, { repo::core::model::NodeType::TRANSFORMATION });
 	if (parents.size()) {
 		return parents[0].getPath() + "->" + name();
 	}

--- a/test/src/unit/repo_test_scene_utils.h
+++ b/test/src/unit/repo_test_scene_utils.h
@@ -32,6 +32,8 @@ namespace testing {
 		{
 		}
 
+		using Filter = std::initializer_list<repo::core::model::NodeType>;
+
 		struct NodeInfo
 		{
 			size_t numVisibleChildren;
@@ -60,12 +62,14 @@ namespace testing {
 
 			NodeInfo getParent() const;
 
+			std::vector<NodeInfo> getParents(Filter parents) const;
+
 			SceneUtils* scene;
 			repo::core::model::RepoNode* node;
 
-			std::vector<NodeInfo> getChildren()
+			std::vector<NodeInfo> getChildren(Filter children)
 			{
-				return scene->getChildNodes(node, true);
+				return scene->getChildNodes(node, children);
 			}
 
 			/* Names of all children (excluding metadata); children that don't
@@ -83,6 +87,8 @@ namespace testing {
 
 			std::vector<NodeInfo> getTextures();
 
+			std::vector<NodeInfo> getSiblings(Filter parents, Filter siblings);
+
 			bool hasTextures();
 
 			std::unordered_map<std::string, repo::lib::RepoVariant> getMetadata();
@@ -98,6 +104,16 @@ namespace testing {
 			bool hasTransparency();
 
 			std::string getPath() const;
+
+            bool operator==(const NodeInfo& other) const
+            {
+				return node->getUniqueID() == other.node->getUniqueID();
+            }
+
+            bool operator!=(const NodeInfo& other) const
+            {
+				return !(*this == other);
+            }
 		};
 
 		std::vector<NodeInfo> findNodesByMetadata(std::string key, std::string value);
@@ -106,9 +122,10 @@ namespace testing {
 		NodeInfo findLeafNode(std::string name);
 		std::vector<NodeInfo> findLeafNodes(std::string name);
 		std::vector<NodeInfo> findTransformationNodesByName(std::string name);
-		std::vector<NodeInfo> getChildNodes(repo::core::model::RepoNode* node, bool ignoreMeta);
-		std::vector<NodeInfo> getParentNodes(repo::core::model::RepoNode* node);
+		std::vector<NodeInfo> getChildNodes(repo::core::model::RepoNode* node, Filter filter);
+		std::vector<NodeInfo> getParentNodes(repo::core::model::RepoNode* node, Filter filter);
 		std::vector<NodeInfo> getMeshes();
+		std::vector<NodeInfo> getMetadataNodes();
 		repo::lib::RepoMatrix getWorldTransform(repo::core::model::RepoNode* node);
 		NodeInfo getNodeInfo(repo::core::model::RepoNode* node);
 		NodeInfo getRootNode();


### PR DESCRIPTION
This fixes #784

This PR adds a processing stage that ensures any metadata within leaf nodes is hooked up.

Leaf nodes are nodes that have only unnamed meshes as children. For these nodes, any metadata parented to the transform should also be parented to the meshes. This is assumed by the backend when it attempts to resolve external ids from metadata, based on the shared ids passed by the viewer (which will be those of possibly hidden mesh nodes, only).

The use of a processing pass is the best approach because the importers have varying degrees of context. Further if the tree logic can adopt the responsibility of identifying what is and is not a composite object in the future, the processing pass can be removed.

A unit test has been added that can that checks that metadata is correctly connected within all leaf nodes in a scene, and this has been added to the tests of all importers that support metadata (all of them except assimp).

The scene test utils have been updated to support this test, which includes making some APIs more explicit. As the previous graph tests did not include this inheritance, the findNodesByMetadata method is now implicitly "find *leaf* nodes by metadata", which reflects its original intent and avoids any changes to the existing tests.