### PR TITLE
Issue #788 Remove new filtering indexes

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_3drepo.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_3drepo.cpp
@@ -172,7 +172,7 @@ public:
 		minBufferSize(0),
 		numMaterials(0)
 	{
-		createIndexes(false);
+		createIndexes();
 	}
 
 	struct Ids

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_ifc.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_ifc.cpp
@@ -52,7 +52,7 @@ repo::core::model::RepoScene* IFCModelImport::importModel(std::string filePath, 
 		settings.getProjectName(),
 		settings.getRevisionId()
 		);
-	sceneBuilder->createIndexes(false);
+	sceneBuilder->createIndexes();
 
 	auto serialiser = ifcUtils::IfcUtils::CreateSerialiser(filePath);
 

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_oda.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_oda.cpp
@@ -60,7 +60,7 @@ repo::core::model::RepoScene* OdaModelImport::importModel(std::string filePath, 
 		settings.getProjectName(),
 		settings.getRevisionId()
 	);
-	sceneBuilder->createIndexes(false);
+	sceneBuilder->createIndexes();
 
 	odaProcessor = odaHelper::FileProcessor::getFileProcessor(filePath, sceneBuilder.get(), settings);
 	auto result = odaProcessor->readFile();

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_builder.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_builder.cpp
@@ -365,7 +365,7 @@ repo::manipulator::modelconvertor::ModelUnits RepoSceneBuilder::getUnits()
 	return this->units;
 }
 
-void RepoSceneBuilder::createIndexes(bool groupingsEnabled)
+void RepoSceneBuilder::createIndexes()
 {
 	using namespace repo::core::handler::database::index;
 	auto historyCollection = projectName + "." + REPO_COLLECTION_HISTORY;
@@ -375,93 +375,7 @@ void RepoSceneBuilder::createIndexes(bool groupingsEnabled)
 	handler->createIndex(databaseName, sceneCollection, Ascending({ REPO_NODE_REVISION_ID, "metadata.key", "metadata.value" }));
 	handler->createIndex(databaseName, sceneCollection, Ascending({ "metadata.key", "metadata.value" }));
 	handler->createIndex(databaseName, sceneCollection, Ascending({ REPO_NODE_REVISION_ID, REPO_NODE_LABEL_SHARED_ID, REPO_LABEL_TYPE }));
-	handler->createIndex(databaseName, sceneCollection, Ascending({ REPO_NODE_LABEL_SHARED_ID }));
-
-	// Indexes for filtering during the supermeshing
-
-	// For getting all Transforms and all Materials
-	// For transforms, this cannot be a covered query because REPO_NODE_LABEL_MATRIX and REPO_NODE_LABEL_PARENTS are both arrays
-	// For materials, this cannot be a covered query because parents, ambient, and diffuse are all arrays
-	handler->createIndex(databaseName, sceneCollection, Ascending({ REPO_NODE_REVISION_ID, REPO_NODE_LABEL_TYPE }));
-
-	// For all groupings
-	// Should be covered query
-	if (groupingsEnabled)
-		handler->createIndex(databaseName, sceneCollection, Ascending({ REPO_NODE_REVISION_ID, REPO_NODE_LABEL_TYPE, REPO_NODE_MESH_LABEL_GROUPING }), true);
-	
-	// For the opaque group
-	// Cannot be a covered query because parents and bounding box are both arrays
-	if(groupingsEnabled)
-		handler->createIndex(databaseName, sceneCollection, Ascending({
-			REPO_NODE_REVISION_ID,
-			REPO_NODE_MESH_LABEL_PRIMITIVE,
-			REPO_NODE_MESH_LABEL_GROUPING,
-			REPO_FILTER_TAG_OPAQUE
-			}), true);
-	else
-		handler->createIndex(databaseName, sceneCollection, Ascending({
-			REPO_NODE_REVISION_ID,
-			REPO_NODE_MESH_LABEL_PRIMITIVE,
-			REPO_FILTER_TAG_OPAQUE
-			}), true);
-
-	// For the transparent group
-	// Cannot be a covered query because parents and bounding box are both arrays
-	if (groupingsEnabled)
-		handler->createIndex(databaseName, sceneCollection, Ascending({
-			REPO_NODE_REVISION_ID,
-			REPO_NODE_MESH_LABEL_PRIMITIVE,
-			REPO_NODE_MESH_LABEL_GROUPING,
-			REPO_FILTER_TAG_TRANSPARENT
-			}), true);
-	else
-		handler->createIndex(databaseName, sceneCollection, Ascending({
-			REPO_NODE_REVISION_ID,
-			REPO_NODE_MESH_LABEL_PRIMITIVE,
-			REPO_FILTER_TAG_TRANSPARENT
-			}), true);
-
-	// Get all texture ids
-	// Should be a covered query
-	if (groupingsEnabled)
-		handler->createIndex(databaseName, sceneCollection, Ascending({
-			REPO_NODE_REVISION_ID,
-			REPO_NODE_LABEL_TYPE,
-			REPO_NODE_MESH_LABEL_GROUPING
-			}), true);
-	// Would be this for without groupings, but already set above in the initial block
-	//else
-	//	handler->createIndex(databaseName, sceneCollection, Ascending({
-	//		REPO_NODE_REVISION_ID,
-	//		REPO_NODE_LABEL_TYPE,
-	//		REPO_NODE_LABEL_SHARED_ID
-	//		}));
-
-	// For the textured group
-	// Cannot be a covered query because parents and bounding box are both arrays
-	if (groupingsEnabled)
-		handler->createIndex(databaseName, sceneCollection, Ascending({
-			REPO_NODE_REVISION_ID,		
-			REPO_NODE_MESH_LABEL_PRIMITIVE,
-			REPO_NODE_MESH_LABEL_GROUPING,
-			REPO_FILTER_TAG_TEXTURE_ID
-			}), true);
-	else
-		handler->createIndex(databaseName, sceneCollection, Ascending({
-			REPO_NODE_REVISION_ID,
-			REPO_FILTER_TAG_TEXTURE_ID
-			}), true);
-	
-	// For pulling extra mesh information during the supermeshing
-	// Should be a covered query
-	handler->createIndex(databaseName, sceneCollection, Ascending({
-		REPO_NODE_LABEL_SHARED_ID,
-		REPO_NODE_MESH_LABEL_VERTICES_COUNT,
-		REPO_NODE_MESH_LABEL_FACES_COUNT,
-		REPO_NODE_MESH_LABEL_UV_CHANNELS_COUNT,
-		REPO_NODE_MESH_LABEL_PRIMITIVE,
-		REPO_LABEL_BINARY_REFERENCE
-		}), true);
+	handler->createIndex(databaseName, sceneCollection, Ascending({ REPO_NODE_LABEL_SHARED_ID }));	
 }
 
 RepoSceneBuilder::AsyncImpl::AsyncImpl(RepoSceneBuilder* builder):

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_builder.h
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_builder.h
@@ -115,7 +115,7 @@ namespace repo {
 				* an index on a large number of nodes at the end.
 				* Some of the indexes this creats could be moved to .io in the future.
 				*/
-				void createIndexes(bool groupingsEnabled);
+				void createIndexes();
 
 			private:
 


### PR DESCRIPTION
This fixes #788 <!-- Enter issue number here -->

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Support new error codes
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.
- Changed some response codes from 500 to 400 (e.g. user uploading a file with no mesh is a user error, not system's)
-->
After finding issues with existing collections on rollout of #745, the decision was made to remove the new indexes for filtering. They are now removed in this PR.


#### Acceptance Criteria
<!-- Copy and paste the acceptance criteria here from the product issue and verify that they all passed 
e.g.
- [x] As a Commenter+, I want to be able to delete images in image preview before I leave the comment.
- [x] As a Commenter+, I want to be able to delete images after I leave the comment.

If you cannot find Acceptance criteria for your issue, check with a member of the QA team
-->

