### PR TITLE
Issue #790 Split Jobs in Multipart Optimizer by Presence of Normals

### DIFF
--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
@@ -121,7 +121,8 @@ namespace repo {
 					const repo::lib::RepoUUID &revId,
 					const int primitive,
 					const std::string &grouping,
-					const bool isOpaque
+					const bool isOpaque,
+					const bool hasNormals
 				);
 
 				ProcessingJob createTexturedJob(
@@ -129,6 +130,7 @@ namespace repo {
 					const repo::lib::RepoUUID &revId,
 					const int primitive,
 					const std::string &grouping,
+					const bool hasNormals,
 					const repo::lib::RepoUUID &texId
 				);
 


### PR DESCRIPTION
This fixes #790<!-- Enter issue number here -->

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Support new error codes
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.
- Changed some response codes from 500 to 400 (e.g. user uploading a file with no mesh is a user error, not system's)
-->
This is a hotfix that splits the jobs of the multipart optimiser into two sets, with one grouping only meshes with normals and one for meshes without.

