### PR TITLE
ISSUE #795 hide the lines under the Models category, as these are effectively annotations

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
@@ -271,6 +271,10 @@ void setupViewOverrides(OdBmDBViewPtr pView)
 
 	ids.push_back(db->getObjectId(OdBm::BuiltInCategory::OST_SunStudy));
 
+	// As are a number of Lines
+
+	ids.push_back(db->getObjectId(OdBm::BuiltInCategory::OST_Lines));
+
 	// We also want to hide topography contours
 
 	ids.push_back(db->getObjectId(OdBm::BuiltInCategory::OST_TopographyContours));

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -414,6 +414,10 @@ TEST(ODAModelImport, DefaultViewVisibility)
 	auto floorNode = utils.findNodeByMetadata("Element ID", "2928847");
 	EXPECT_THAT(floorNode.getMeshes(repo::core::model::MeshNode::Primitive::TRIANGLES), Not(IsEmpty()));
 	EXPECT_THAT(floorNode.getMeshes(repo::core::model::MeshNode::Primitive::LINES), IsEmpty());
+
+	// The Lines model category should be treated as an annotation, and not
+	// processed
+	EXPECT_THAT(utils.findNodesByMetadata("Category", "Lines"), IsEmpty());
 }
 
 TEST(ODAModelImport, NamedView)


### PR DESCRIPTION
This fixes #795

#### Description
This PR turns off the Lines category when updating the default view, in order to hide Model entries that are effectively annotations, in keeping with the new expected import behaviour, which is not to import annotations.

