### PR TITLE
ISSUE #808 fix scale for all revit units

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -212,7 +212,7 @@ void DataProcessorRvt::initialise(GeometryCollector* collector, OdBmDatabasePtr 
 	this->collector = collector;
 	this->view = view;
 	this->modelToProjectCoordinates = modelToWorld;
-	collector->setUnits(getProjectUnits(pDb));
+	collector->setUnits(repo::manipulator::modelconvertor::ModelUnits::FEET); // For Revit, the API always uses the internal coordinate system units, which are ft.
 }
 
 void DataProcessorRvt::beginViewVectorization()
@@ -724,27 +724,6 @@ OdBmAUnitsPtr DataProcessorRvt::getUnits(OdBmDatabasePtr database)
 	OdBmUnitsElemPtr pUnitsElem = pUnitsTracking->getUnitsElemId().safeOpenObject();
 	OdBmAUnitsPtr ptrAUnits = pUnitsElem->getUnits().get();
 	return ptrAUnits;
-}
-
-OdBmForgeTypeId DataProcessorRvt::getLengthUnits(OdBmDatabasePtr database)
-{
-	OdBmFormatOptionsPtr formatOptionsLength = getUnits(database)->getFormatOptions(OdBmSpecTypeId::kLength);
-	return formatOptionsLength->getUnitTypeId();
-}
-
-ModelUnits DataProcessorRvt::getProjectUnits(OdBmDatabasePtr pDb) {
-	initLabelUtils();
-	auto unitsStr = convertToStdString(labelUtils->getLabelForUnit(getLengthUnits(pDb)));
-
-	if (unitsStr == "Millimeters") return ModelUnits::MILLIMETRES;
-	if (unitsStr == "Centimeters") return ModelUnits::CENTIMETRES;
-	if (unitsStr == "Decimeters") return ModelUnits::DECIMETRES;
-	if (unitsStr == "Meters") return ModelUnits::METRES;
-	if (unitsStr == "Feet") return ModelUnits::FEET;
-	if (unitsStr == "Inches") return ModelUnits::INCHES;
-
-	repoWarning << "Unrecognised model units: " << unitsStr;
-	return ModelUnits::UNKNOWN;
 }
 
 repo::lib::RepoVector3D64 DataProcessorRvt::convertToRepoWorldCoordinates(OdGePoint3d p)

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.h
@@ -125,8 +125,6 @@ namespace repo {
 						const OdBm::BuiltInParameter::Enum &buildInEnum
 					);
 
-					ModelUnits getProjectUnits(OdBmDatabasePtr pDb);
-
 					OdBmDatabasePtr database;
 					OdBmDBViewPtr view;
 					OdBmSampleLabelUtilsPE* labelUtils = nullptr;

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
@@ -417,10 +417,6 @@ OdGeMatrix3d getModelToWorldMatrix(OdBmDatabasePtr pDb)
 				OdGeMatrix3d activeTransform = pActiveLocation->getTransform();
 				activeTransform.invert();
 
-				auto units = DataProcessorRvt::getLengthUnits(pDb);
-				auto scaleCoef = 1.0 / OdBmUnitUtils::getUnitTypeIdInfo(units).inIntUnitsCoeff;
-				activeTransform.preMultBy(OdGeMatrix3d::scaling(OdGeScale3d(scaleCoef)));
-
 				return activeTransform;
 			}
 		}

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -582,6 +582,47 @@ TEST(ODAModelImport, DefaultViewDisplayOptions)
 	}
 }
 
+TEST(ODAModelImport, RvtUnits)
+{
+	// In mm
+	auto expectedBounds = repo::lib::RepoBounds(
+		repo::lib::RepoVector3D64(-708.47, -2500.0, -62.05),
+		repo::lib::RepoVector3D64(-403.17, 0.0, 245.84)
+	);
+
+	// Regardless of what the project units are, the geometry should always be
+	// imported in the target units of the import config (and correctly scaled
+	// to those units).
+
+	{
+		ModelImportConfig config(repo::lib::RepoUUID::createUUID(), TESTDB, "RevitUnitsMillimeters");
+		config.targetUnits = ModelUnits::MILLIMETRES;
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport(getDataPath("rvt_mm.rvt"), config));
+		EXPECT_THAT(scene.findNodeByMetadata("Element ID", "330859").getProjectBounds(), BoundsAre(expectedBounds, 0.5));
+	}
+
+	{
+		ModelImportConfig config(repo::lib::RepoUUID::createUUID(), TESTDB, "RevitUnitsFeet");
+		config.targetUnits = ModelUnits::MILLIMETRES;
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport(getDataPath("rvt_ft.rvt"), config));
+		EXPECT_THAT(scene.findNodeByMetadata("Element ID", "330859").getProjectBounds(), BoundsAre(expectedBounds, 0.5));
+	}
+
+	{
+		ModelImportConfig config(repo::lib::RepoUUID::createUUID(), TESTDB, "RevitUnitsFeetandFractionalInches");
+		config.targetUnits = ModelUnits::MILLIMETRES;
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport(getDataPath("rvt_ft-in.rvt"), config));
+		EXPECT_THAT(scene.findNodeByMetadata("Element ID", "330859").getProjectBounds(), BoundsAre(expectedBounds, 0.5));
+	}
+
+	{
+		ModelImportConfig config(repo::lib::RepoUUID::createUUID(), TESTDB, "RevitUnitsShaku");
+		config.targetUnits = ModelUnits::MILLIMETRES;
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport(getDataPath("rvt_shaku.rvt"), config));
+		EXPECT_THAT(scene.findNodeByMetadata("Element ID", "330859").getProjectBounds(), BoundsAre(expectedBounds, 0.5));
+	}
+}
+
 TEST_F(NwdTestSuite, MetadataParentsNWD)
 {
 	// All metadata nodes must also have their sibling meshnodes as parents,

--- a/test/src/unit/repo_test_scene_utils.cpp
+++ b/test/src/unit/repo_test_scene_utils.cpp
@@ -284,6 +284,15 @@ std::vector<repo::core::model::MeshNode> SceneUtils::NodeInfo::getMeshesInProjec
 	return meshes;
 }
 
+repo::lib::RepoBounds SceneUtils::NodeInfo::getProjectBounds()
+{
+	repo::lib::RepoBounds bounds;
+	for (auto& m : getMeshesInProjectCoordinates()) {
+		bounds.encapsulate(m.getBoundingBox());
+	}
+	return bounds;
+}
+
 bool SceneUtils::NodeInfo::hasTextures()
 {
 	return getTextures().size();

--- a/test/src/unit/repo_test_scene_utils.h
+++ b/test/src/unit/repo_test_scene_utils.h
@@ -87,6 +87,8 @@ namespace testing {
 
 			std::vector<repo::core::model::MeshNode> getMeshesInProjectCoordinates();
 
+			repo::lib::RepoBounds getProjectBounds();
+
 			std::vector<NodeInfo> getTextures();
 
 			std::vector<NodeInfo> getSiblings(Filter parents, Filter siblings);


### PR DESCRIPTION
This fixes #808

#### Description
This PR updates the Revit importer to import all geometry in the internal Revit units (ft), and have the Model Import Manager apply a scale to the chosen Model Import Config units from this, instead of trying to set the imported units based on the Project Settings.

Since we scaled to mm, or whatever the user chooses, anyway, there is no need to convert to project units first, and this way we don't need to be aware of all the Revit unit systems, because they don't affect the import.

A new unit test has been added, including more rarely encountered units which we don't have internal equivalents of.
