### PR TITLE
ISSUE #833 dont try and process uvs for nwds

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_nwd.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_nwd.cpp
@@ -657,27 +657,22 @@ void addTriangleData(
 {
 	const OdGePoint3dArray& aVertices = aVertexesData->getVertices();
 	const OdGeVector3dArray& aNormals = aVertexesData->getNormals();
-	const OdGePoint2dArray& aUvs = aVertexesData->getTexCoords();
+
+	// Textures are ignored for now, but if we wish to process them in the future
+	// the Uv coordinates are accessed nominally via the getTexCoords() member of
+	// OdNwVerticesData. Take care that we have encountered models before where
+	// the texcoords and vertices arrays are different lengths, so the necessary
+	// transformation of Uvs should be investigated properly if this is ever
+	// reintroduced.
 
 	for (auto triangle = aTrianglesBegin; triangle != aTrianglesEnd; triangle++)
 	{
 		RepoMeshBuilder::face face;
-
 		face.setVertices({
 			convertPoint(aVertices[triangle->pointIndex1], transformMatrix),
 			convertPoint(aVertices[triangle->pointIndex2], transformMatrix),
 			convertPoint(aVertices[triangle->pointIndex3], transformMatrix)
 			});
-
-		if (aUvs.length())
-		{
-			face.setUvs({
-				convertPoint(aUvs[triangle->pointIndex1]),
-				convertPoint(aUvs[triangle->pointIndex2]),
-				convertPoint(aUvs[triangle->pointIndex3])
-				});
-		}
-
 		meshBuilder.addFace(face);
 	}
 }


### PR DESCRIPTION
This fixes #833

#### Description
This PR stops the NWD importer checking for Uvs and adding them to faces.

The reason is that we encountered a model where the number of uvs did not equal the number of vertices, leading to an access violation. Since we don't support textures for NWDs there is no reason to be accessing this array anyway.

There are no corresponding unit test updates, because we never unit tested Uvs for NWDs, as textures are not supported.

The file from the support request that previously broke now imports OK.