### PR TITLE
Issue #857 getBoundsForContainer not working properly

### DIFF
--- a/bouncer/src/repo/manipulator/modelutility/clashdetection/geometry_tests.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/clashdetection/geometry_tests.cpp
@@ -359,10 +359,10 @@ double geometry::contactThreshold(
 }
 
 double geometry::contactThreshold(
-	const repo::lib::RepoBounds& bound
+	const repo::lib::RepoBounds& scope
 )
 {
-	return cpt(bound);
+	return cpt(scope);
 }
 
 double geometry::orient(const repo::lib::RepoVector3D64& p, const repo::lib::RepoVector3D64& q, const repo::lib::RepoVector3D64& r, const repo::lib::RepoVector3D64& s)

--- a/bouncer/src/repo/manipulator/modelutility/clashdetection/geometry_tests.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/clashdetection/geometry_tests.cpp
@@ -358,6 +358,13 @@ double geometry::contactThreshold(
 	return cpt(repo::lib::RepoBounds({a.min(), a.max(), b.min(), b.max()}));
 }
 
+double geometry::contactThreshold(
+	const repo::lib::RepoBounds& bound
+)
+{
+	return cpt(bound);
+}
+
 double geometry::orient(const repo::lib::RepoVector3D64& p, const repo::lib::RepoVector3D64& q, const repo::lib::RepoVector3D64& r, const repo::lib::RepoVector3D64& s)
 {
 	return predicates::orient3d((double*)&p, (double*)&q, (double*)&r, (double*)&s);

--- a/bouncer/src/repo/manipulator/modelutility/clashdetection/geometry_tests.h
+++ b/bouncer/src/repo/manipulator/modelutility/clashdetection/geometry_tests.h
@@ -161,6 +161,10 @@ namespace geometry {
         const repo::lib::RepoBounds& b
     );
 
+    double contactThreshold(
+        const repo::lib::RepoBounds& bound
+    );
+
     /*
     * The distance threshold to use for coplanarity tests. This is primarily for
 	* the intersects method, but may be useful elsewhere.

--- a/bouncer/src/repo/manipulator/modelutility/clashdetection/geometry_tests.h
+++ b/bouncer/src/repo/manipulator/modelutility/clashdetection/geometry_tests.h
@@ -150,19 +150,36 @@ namespace geometry {
     * way in which the operands combine, and the scalar, are implementation
     * details found empirically.
     */
-
     double contactThreshold(
         const repo::lib::RepoTriangle& a, 
         const repo::lib::RepoTriangle& b
     );
 
+    /*
+    * Given two bounding boxes, return a value representing the uncertainty of
+    * queries run on them due to rounding error. This value can be used to
+    * distinguish between in-contact, in-collision, and coplanar states.
+    *
+    * The value is based on the magnitude of the operands involved - the exact
+    * way in which the operands combine, and the scalar, are implementation
+    * details found empirically.
+    */
     double contactThreshold(
         const repo::lib::RepoBounds& a,
         const repo::lib::RepoBounds& b
     );
 
+    /*
+    * Given a single bounding box, return a value representing the uncertainty
+    * of queries run on it due to rounding error. This value can be used to
+    * distinguish between in-contact, in-collision, and coplanar states.
+    *
+    * The value is based on the magnitude of the operands involved - the exact
+    * way in which the operands combine, and the scalar, are implementation
+    * details found empirically.
+    */
     double contactThreshold(
-        const repo::lib::RepoBounds& bound
+        const repo::lib::RepoBounds& scope
     );
 
     /*

--- a/test/src/unit/repo/manipulator/modelutility/clashdetection/ut_repo_geometry.cpp
+++ b/test/src/unit/repo/manipulator/modelutility/clashdetection/ut_repo_geometry.cpp
@@ -606,6 +606,13 @@ TEST(Geometry, ContactThreshold)
 
 		EXPECT_THAT(geometry::contactThreshold(ab, bb), Ge(th));
 
+		// If we take the bound of all vertices of both triangles, the contact threshold
+		// of the bounds must always be equal to or larger than that of the triangles
+		// themselves.
+		auto abb = repo::lib::RepoBounds({ a.a, a.b, a.c, b.a, b.b, b.c });
+
+		EXPECT_THAT(geometry::contactThreshold(abb), Ge(th));
+
 		// The purpose of the threshold is to participate in the control flow
 		// of algorithms, so we test it in that context: triangles are positioned
 		// into what should be the closest we can get to an in-contact state.

--- a/test/src/unit/repo/manipulator/modelutility/ut_repo_clash_detection.cpp
+++ b/test/src/unit/repo/manipulator/modelutility/ut_repo_clash_detection.cpp
@@ -2919,37 +2919,6 @@ void RunMeetTest(
 	EXPECT_THAT(config.setA.size(), Eq(noSamples));
 	EXPECT_THAT(config.setB.size(), Eq(noSamples));
 
-	// Get map from unique mesh ids to bounds from DB
-	std::unordered_map<repo::lib::RepoUUID, repo::lib::RepoBounds, repo::lib::RepoUUIDHasher> uidToBoundsMap;
-	helper.getBoundsForContainer(container.get(), uidToBoundsMap);
-
-	// Remap to the composite ids
-	std::unordered_map<repo::lib::RepoUUID, repo::lib::RepoBounds, repo::lib::RepoUUIDHasher> compidToBoundsMap;
-	for (auto compObj : config.setA)
-	{
-		repo::lib::RepoBounds bounds;
-		for (auto& mesh : compObj.meshes)
-		{
-			auto uid = mesh.uniqueId;
-			auto boundsEntry = uidToBoundsMap.find(uid);
-			if (boundsEntry != uidToBoundsMap.end())
-				bounds.encapsulate(boundsEntry->second);
-		}
-		compidToBoundsMap.insert({ compObj.id, bounds });
-	}
-	for (auto compObj : config.setB)
-	{
-		repo::lib::RepoBounds bounds;
-		for (auto& mesh : compObj.meshes)
-		{
-			auto uid = mesh.uniqueId;
-			auto boundsEntry = uidToBoundsMap.find(uid);
-			if (boundsEntry != uidToBoundsMap.end())
-				bounds.encapsulate(boundsEntry->second);
-		}
-		compidToBoundsMap.insert({ compObj.id, bounds });
-	}
-
 	// Test Clearance Mode
 	// Low Tolerance
 	{
@@ -2964,20 +2933,14 @@ void RunMeetTest(
 		// the threshold
 		for (auto clash : results.clashes)
 		{
-			auto boundsEntryA = compidToBoundsMap.find(clash.idA);
-			auto boundsEntryB = compidToBoundsMap.find(clash.idB);
+			// Create bounds from the clash positions and origin to calibrate the contact threshold
+			// without having to pull the actual vertices from the database.
+			auto bounds = repo::lib::RepoBounds(clash.positions.data(), clash.positions.size());
+			bounds.encapsulate(repo::lib::RepoVector3D64{ 0,0,0 });
+			double threshold = geometry::contactThreshold(bounds);
 
-			if (boundsEntryA != compidToBoundsMap.end() && boundsEntryB != compidToBoundsMap.end())
-			{
-				float threshold = geometry::contactThreshold(boundsEntryA->second, boundsEntryB->second);
-
-				float diff = (clash.positions[0] - clash.positions[1]).norm();
-				EXPECT_THAT(diff, Le(threshold));
-			}
-			else
-			{
-				FAIL() << "Could not retrieve bounds for either or both of the composites";
-			}
+			double diff = (clash.positions[0] - clash.positions[1]).norm();
+			EXPECT_THAT(diff, Le(threshold));
 		}
 	}
 
@@ -2995,20 +2958,14 @@ void RunMeetTest(
 		// the threshold
 		for (auto clash : results.clashes)
 		{
-			auto boundsEntryA = compidToBoundsMap.find(clash.idA);
-			auto boundsEntryB = compidToBoundsMap.find(clash.idB);
+			// Create bounds from the clash positions and origin to calibrate the contact threshold
+			// without having to pull the actual vertices from the database.
+			auto bounds = repo::lib::RepoBounds(clash.positions.data(), clash.positions.size());
+			bounds.encapsulate(repo::lib::RepoVector3D64{ 0,0,0 });
+			double threshold = geometry::contactThreshold(bounds);
 
-			if (boundsEntryA != compidToBoundsMap.end() && boundsEntryB != compidToBoundsMap.end())
-			{
-				float threshold = geometry::contactThreshold(boundsEntryA->second, boundsEntryB->second);
-
-				float diff = (clash.positions[0] - clash.positions[1]).norm();
-				EXPECT_THAT(diff, Le(threshold));
-			}
-			else
-			{
-				FAIL() << "Could not retrieve bounds for either or both of the composites";
-			}
+			double diff = (clash.positions[0] - clash.positions[1]).norm();
+			EXPECT_THAT(diff, Le(threshold));
 		}
 	}
 

--- a/test/src/unit/repo_test_clash_utils.cpp
+++ b/test/src/unit/repo_test_clash_utils.cpp
@@ -663,32 +663,6 @@ void ClashDetectionDatabaseHelper::createCompositeObjectsByMetadataValue(
 	}
 }
 
-void ClashDetectionDatabaseHelper::getBoundsForContainer(
-	repo::lib::Container* container,
-	std::unordered_map<repo::lib::RepoUUID, repo::lib::RepoBounds, repo::lib::RepoUUIDHasher>& boundsMap)
-{
-	repo::core::handler::database::query::RepoQueryBuilder query;
-	query.append(repo::core::handler::database::query::Eq(REPO_NODE_LABEL_TYPE, REPO_NODE_TYPE_MESH));
-
-	repo::core::handler::database::query::RepoProjectionBuilder projection;
-	projection.includeField(REPO_NODE_MESH_LABEL_BOUNDING_BOX);
-	projection.includeField(REPO_NODE_LABEL_ID);
-
-	auto cursor = handler->findCursorByCriteria(
-		container->teamspace,
-		container->container + "." + REPO_COLLECTION_SCENE,
-		query,
-		projection
-	);
-
-	for (auto& bson : *cursor) {
-		repo::lib::RepoUUID id = bson.getUUIDField(REPO_NODE_LABEL_ID);
-		repo::lib::RepoBounds bounds = bson.getBoundsField(REPO_NODE_MESH_LABEL_BOUNDING_BOX);
-
-		boundsMap.insert({ id, bounds });
-	}
-}
-
 CompositeObject testing::combineCompositeObjects(
 	std::initializer_list<CompositeObject> objects
 )

--- a/test/src/unit/repo_test_clash_utils.h
+++ b/test/src/unit/repo_test_clash_utils.h
@@ -173,10 +173,6 @@ namespace testing {
 			const std::string& value,
 			std::unordered_map<repo::lib::RepoUUID, std::unordered_map<std::string, repo::lib::RepoVariant>, repo::lib::RepoUUIDHasher>& metadataMap);
 
-		void getBoundsForContainer(
-			repo::lib::Container* container,
-			std::unordered_map<repo::lib::RepoUUID, repo::lib::RepoBounds, repo::lib::RepoUUIDHasher>& boundsMap);
-
 		std::unique_ptr<repo::lib::Container> getContainerByName(
 			std::string name);
 	};


### PR DESCRIPTION
This fixes #857

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Support new error codes
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.
- Changed some response codes from 500 to 400 (e.g. user uploading a file with no mesh is a user error, not system's)
-->
The problem was caused by the contact threshold being too strict. This happened because it based it on local bounds and hence could not account for quantisation errors happening with far-away geometry. This was fixed by feeding in custom bounds, based on the contact points and the origin. This allows for a more appropriate threshold without having to retrieve all the geometry of the meshes from the db.


