### PR TITLE
Issue 859 - support v5 configs

### DIFF
--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -404,8 +404,18 @@ int32_t importFileAndCommit(
 			tag = jsonTree.get<std::string>("tag", "");
 			desc = jsonTree.get<std::string>("desc", "");
 
-			config.databaseName = jsonTree.get<std::string>("database", "");
-			config.projectName = jsonTree.get<std::string>("project", "");
+			// Client should be backwards compatible with v4 (database & project) and v5
+			// (teamspace & container) terminology. Teamspace/database are the terms that
+			// do not conflict, so we use them to distinguish which version is being used.
+
+			config.databaseName = jsonTree.get<std::string>("teamspace", "");
+			config.projectName = jsonTree.get<std::string>("container", "");
+
+			if (config.databaseName.empty()) {
+				config.databaseName = jsonTree.get<std::string>("database", "");
+				config.projectName = jsonTree.get<std::string>("project", "");
+			}
+
 			config.timeZone = jsonTree.get<std::string>("timezone", config.timeZone);
 			config.targetUnits = units::fromString(jsonTree.get<std::string>("units", ""));
 			config.lod = jsonTree.get<int>("lod", config.lod);
@@ -500,7 +510,14 @@ int32_t processDrawing(
 	try {
 		boost::property_tree::read_json(command.args[0], jsonTree);
 
-		database = jsonTree.get<std::string>("database", "");
+		// Support both v4 and v5 config terminology for backwards compatibility
+
+		database = jsonTree.get<std::string>("teamspace", {});
+
+		if (database.empty()) {
+			database = jsonTree.get<std::string>("database", "");
+		}
+
 		auto revisionStr = jsonTree.get<std::string>("revId", "");
 
 		if (database.empty() || revisionStr.empty())

--- a/tools/bouncer_worker/src/lib/messageDecoder.js
+++ b/tools/bouncer_worker/src/lib/messageDecoder.js
@@ -51,8 +51,8 @@ const messageDecoder = (cmd) => {
 					const cmdFile = require(args[2]);
 					res = {
 						cmdParams: [configPath, ...args],
-						database: cmdFile.database,
-						model: cmdFile.project,
+						teamspace: cmdFile.teamspace,
+						container: cmdFile.container,
 						user: cmdFile.owner,
 						file: cmdFile.file,
 						...res,
@@ -65,8 +65,8 @@ const messageDecoder = (cmd) => {
 					const cmdFile = require(args[1]);
 					res = {
 						cmdParams: [configPath, ...args],
-						database: cmdFile.database,
-						model: cmdFile.project,
+						teamspace: cmdFile.teamspace,
+						drawing: cmdFile.drawing,
 						user: cmdFile.owner,
 						file: cmdFile.file,
 						format: cmdFile.format,
@@ -81,8 +81,8 @@ const messageDecoder = (cmd) => {
 					const cmdFile = require(args[1]);
 					res = {
 						cmdParams: [configPath, ...args],
-						database: cmdFile.database,
-						model: cmdFile.project,
+						teamspace: cmdFile.teamspace,
+						federation: cmdFile.federation,
 						user: cmdFile.owner,
 						...res,
 					};
@@ -100,8 +100,8 @@ const messageDecoder = (cmd) => {
 			case 'genStash':
 				res = {
 					cmdParams: [configPath, ...args],
-					database: args[1],
-					model: args[2],
+					teamspace: args[1],
+					container: args[2],
 					...res,
 				};
 				break;

--- a/tools/bouncer_worker/src/lib/utils.js
+++ b/tools/bouncer_worker/src/lib/utils.js
@@ -36,7 +36,7 @@ Utils.getCurrentDateTimeAsString = () => moment().format('YYYY-MM-DD_HH[h]mm[m]s
 Utils.gatherProcessInformation = (
 	owner,
 	model,
-	database,
+	teamspace,
 	queue,
 	repoLicense,
 	rid,
@@ -46,7 +46,7 @@ Utils.gatherProcessInformation = (
 		Owner: owner,
 		Model: model,
 		Rid: rid,
-		Database: database,
+		Database: teamspace,
 		Queue: queue, // logLabel.label,
 		licenseKey: repoLicense,
 	});

--- a/tools/bouncer_worker/src/queues/clashQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/clashQueueHandler.js
@@ -22,6 +22,7 @@ const { runBouncerCommand } = require('../tasks/bouncerClient');
 const { messageDecoder } = require('../lib/messageDecoder');
 const logger = require('../lib/logger');
 const { CLASH } = require('../constants/messageTypes');
+const { PROCESSING } = require('../constants/statuses');
 const Utils = require('../lib/utils');
 const ProcessMonitor = require('../lib/processMonitor');
 
@@ -37,6 +38,15 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 		callback(JSON.stringify({ value: errorCode }));
 		return;
 	}
+
+	// A short pause before we update the model status as sometimes this happens so fast that
+	// it preceeds the amqp confirming to io that the item has been queued.
+	await Utils.sleep(100);
+	callback(JSON.stringify({
+		status: PROCESSING,
+		teamspace,
+		project,
+	}));
 
 	// Use the CLI to specify where the results file should go. Each clash run
 	// should have its own folder, so we don't need to generate a unique name.

--- a/tools/bouncer_worker/src/queues/clashQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/clashQueueHandler.js
@@ -44,6 +44,7 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	await Utils.sleep(100);
 	callback(JSON.stringify({
 		status: PROCESSING,
+		type: CLASH,
 		teamspace,
 		project,
 	}));

--- a/tools/bouncer_worker/src/queues/drawingQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/drawingQueueHandler.js
@@ -30,11 +30,11 @@ const { DRAWING } = require('../constants/messageTypes');
 const Handler = {};
 const logLabel = { label: 'DRAWINGQ' };
 
-const generateTaskProfile = (user, model, database, rid, format, size) => ({
+const generateTaskProfile = (user, drawing, teamspace, rid, format, size) => ({
 	...Utils.gatherProcessInformation(
 		user,
-		model,
-		database,
+		drawing,
+		teamspace,
 		logLabel.label, // queue
 		config.repoLicense,
 		rid,
@@ -47,7 +47,7 @@ const generateTaskProfile = (user, model, database, rid, format, size) => ({
 Handler.onMessageReceived = async (cmd, rid, callback) => {
 	const ridString = rid.toString();
 	const logDir = Path.join(config.logging.taskLogDir, ridString);
-	const { errorCode, database, model, user, cmdParams, format, size, file } = messageDecoder(cmd);
+	const { errorCode, teamspace, drawing, user, cmdParams, format, size, file } = messageDecoder(cmd);
 
 	if (errorCode) {
 		callback(JSON.stringify({ value: errorCode }));
@@ -59,20 +59,20 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	await Utils.sleep(100);
 	callback(JSON.stringify({
 		status: PROCESSING,
-		database,
-		project: model,
+		teamspace,
+		drawing,
 	}));
 
 	const returnMessage = {
 		value: ERRCODE_OK,
-		teamspace: database,
-		container: model,
+		teamspace,
+		drawing,
 		user,
 		type: DRAWING,
 	};
 
 	try {
-		const procInfo = generateTaskProfile(user, model, database, ridString, format, size);
+		const procInfo = generateTaskProfile(user, drawing, teamspace, ridString, format, size);
 
 		if (format === '.pdf') {
 			const svgPath = Path.join(logDir, `${ridString}.svg`);

--- a/tools/bouncer_worker/src/queues/jobQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/jobQueueHandler.js
@@ -25,11 +25,11 @@ const Handler = {};
 
 const logLabel = { label: 'JOBQ' };
 
-const createFed = async ({ database, model, cmdParams }, logDir) => {
+const createFed = async ({ teamspace, federation, cmdParams }, logDir) => {
 	const returnMessage = {
 		value: ERRCODE_OK,
-		teamspace: database,
-		container: model,
+		teamspace,
+		federation,
 	};
 	try {
 		returnMessage.value = await runBouncerCommand(logDir, cmdParams);

--- a/tools/bouncer_worker/src/queues/modelQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/modelQueueHandler.js
@@ -31,7 +31,7 @@ const logLabel = { label: 'MODELQ' };
 
 Handler.onMessageReceived = async (cmd, rid, callback) => {
 	const logDir = `${config.logging.taskLogDir}/${rid.toString()}/`;
-	const { errorCode, database, model, user, cmdParams, file } = messageDecoder(cmd);
+	const { errorCode, teamspace, container, user, cmdParams, file } = messageDecoder(cmd);
 
 	if (errorCode) {
 		callback(JSON.stringify({ value: errorCode }));
@@ -43,14 +43,14 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	await Utils.sleep(100);
 	callback(JSON.stringify({
 		status: PROCESSING,
-		database,
-		project: model,
+		teamspace,
+		container,
 	}));
 
 	const returnMessage = {
 		value: ERRCODE_OK,
-		teamspace: database,
-		container: model,
+		teamspace,
+		container,
 		user,
 		type: IMPORT,
 	};
@@ -60,8 +60,8 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	try {
 		const processInformation = Utils.gatherProcessInformation(
 			user,
-			model,
-			database,
+			container,
+			teamspace,
 			logLabel.label, // queue
 			config.repoLicense,
 			ridString,

--- a/tools/bouncer_worker/src/queues/modelQueueHandler.js
+++ b/tools/bouncer_worker/src/queues/modelQueueHandler.js
@@ -25,6 +25,7 @@ const logger = require('../lib/logger');
 const processMonitor = require('../lib/processMonitor');
 const Utils = require('../lib/utils');
 const { IMPORT } = require('../constants/messageTypes');
+const { MODEL } = require('../constants/queueLabels');
 
 const Handler = {};
 const logLabel = { label: 'MODELQ' };
@@ -43,6 +44,7 @@ Handler.onMessageReceived = async (cmd, rid, callback) => {
 	await Utils.sleep(100);
 	callback(JSON.stringify({
 		status: PROCESSING,
+		type: MODEL,
 		teamspace,
 		container,
 	}));

--- a/tools/bouncer_worker/src/tasks/bouncerClient.js
+++ b/tools/bouncer_worker/src/tasks/bouncerClient.js
@@ -74,8 +74,8 @@ BouncerHandler.runBouncerCommand = async (
 	return run(bouncerClientPath, cmdParams, { codesAsSuccess: BOUNCER_SOFT_FAILS, logLabel: { label: 'BOUNCER' } }, processInformation);
 };
 
-BouncerHandler.generateTreeStash = async (logDir, database, modelId, stashType, rev = 'all') => {
-	const cmd = [configPath, 'genStash', database, modelId, stashType, rev];
+BouncerHandler.generateTreeStash = async (logDir, teamspace, container, stashType, rev = 'all') => {
+	const cmd = [configPath, 'genStash', teamspace, container, stashType, rev];
 	return BouncerHandler.runBouncerCommand(logDir, cmd);
 };
 


### PR DESCRIPTION
This fixes #859

#### Description
This makes minor changes so that bouncer_worker operates exclusively with v5 conventions, and bouncer itself can use v4 or v5 conventions.

Only the model and drawing functions have been updated in bouncer, as genStash operates exclusively with command line arguments, and federations are no longer supported.

Clash detection does not need any changes as this already/only works with the new conventions.
