### PR TITLE
Issue 842 - Support splitting by floors

### DIFF
--- a/bouncer/src/repo/core/handler/database/repo_query.h
+++ b/bouncer/src/repo/core/handler/database/repo_query.h
@@ -144,6 +144,30 @@ namespace repo {
 						std::vector<RepoQuery> conditions;
 					};
 
+					class REPO_API_EXPORT ArrayContains
+					{
+					public:
+						template<typename T>
+						ArrayContains(std::string array, T query)
+							:field(array),
+							q({query})
+						{
+						}
+
+						std::string field;
+
+						const RepoQuery& query() const {
+							return q[0];
+						}
+
+					private:
+						// Variants must know the size of their types ahead of time, so we cannot
+						// have circular definitions. We use a vector as a trivial indirection as
+						// this container has all the necessary traits (copyable, assignable,
+						// trivially destructible, etc), but it will only ever store one element.
+						std::vector<RepoQuery> q;
+					};
+
 					/*
 					 * Convenience type to help build more complex composite queries in multiple
 					 * stages.

--- a/bouncer/src/repo/core/handler/database/repo_query.h
+++ b/bouncer/src/repo/core/handler/database/repo_query.h
@@ -95,6 +95,12 @@ namespace repo {
 							values.push_back(value);
 						}
 
+						Eq(const char* field, const char* value)
+							: field(field)
+						{
+							values.push_back(std::string(value));
+						}
+
 						template<typename T>
 						Eq(const char* field, const T& value)
 							: field(std::string(field))

--- a/bouncer/src/repo/core/handler/database/repo_query_fwd.h
+++ b/bouncer/src/repo/core/handler/database/repo_query_fwd.h
@@ -27,12 +27,13 @@ namespace repo {
 					class Eq;
 					class Exists;
 					class Or;
+					class ArrayContains;
 					class RepoQueryBuilder;
 					class RepoProjectionBuilder;
 
 					class AddParent;
 
-					using RepoQuery = std::variant<Eq, Exists, Or, RepoQueryBuilder, RepoProjectionBuilder>;
+					using RepoQuery = std::variant<Eq, Exists, Or, ArrayContains, RepoQueryBuilder, RepoProjectionBuilder>;
 
 					using RepoUpdate = std::variant<AddParent>;
 				}

--- a/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
+++ b/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
@@ -181,6 +181,18 @@ struct MongoQueryFilterVistior
 		builder->append(n.field, criteria.obj());
 	}
 
+	void operator() (const query::ArrayContains& n) const
+	{
+		// The array contains operator is a special case of the exists operator,
+		// where the field to check for existence is an element of an array. This
+		// uses the 'elemMatch' operator, which takes a document of query operators
+		// to apply to the elements of the array.
+
+		repo::core::model::RepoBSONBuilder criteria;
+		criteria.append("$elemMatch", makeQueryFilterDocument(n.query()));
+		builder->append(n.field, criteria.obj());
+	}
+
 	void operator() (const query::Or& n) const
 	{
 		// The Or operator is special in that it should exist at the top level

--- a/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
+++ b/bouncer/src/repo/core/handler/repo_database_handler_mongo.cpp
@@ -925,7 +925,7 @@ std::unique_ptr<Cursor> repo::core::handler::MongoDatabaseHandler::findCursorByC
 		}
 		else
 		{
-			return nullptr;
+			throw MongoDatabaseHandlerException(*this, "Invalid call to findCursorByCriteria; all of database, collection, and criteria must be provided.");
 		}
 
 	}

--- a/bouncer/src/repo/core/model/bson/repo_bson_assets.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson_assets.cpp
@@ -82,6 +82,9 @@ RepoAssets::operator RepoBSON() const
 		metadataBuilder.appendVector3DObject(REPO_ASSETS_LABEL_MAX, meta.max);
 		metadataBuilder.append(REPO_ASSETS_LABEL_NUMSUBMESHES, (int32_t)meta.numSubmeshes);
 		metadataBuilder.append(REPO_ASSETS_LABEL_NUMCOMPONENTS, (int32_t)meta.numComponents);
+		if (meta.groups.size()) {
+			metadataBuilder.appendArray(REPO_ASSETS_LABEL_GROUP, meta.groups);
+		}
 		metadataNodes.push_back(metadataBuilder.obj());
 	}
 

--- a/bouncer/src/repo/core/model/bson/repo_bson_assets.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson_assets.cpp
@@ -83,7 +83,7 @@ RepoAssets::operator RepoBSON() const
 		metadataBuilder.append(REPO_ASSETS_LABEL_NUMSUBMESHES, (int32_t)meta.numSubmeshes);
 		metadataBuilder.append(REPO_ASSETS_LABEL_NUMCOMPONENTS, (int32_t)meta.numComponents);
 		if (meta.groups.size()) {
-			metadataBuilder.appendArray(REPO_ASSETS_LABEL_GROUP, meta.groups);
+			metadataBuilder.appendArray(REPO_ASSETS_LABEL_GROUPS, meta.groups);
 		}
 		metadataNodes.push_back(metadataBuilder.obj());
 	}

--- a/bouncer/src/repo/core/model/bson/repo_bson_assets.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_bson_assets.cpp
@@ -18,6 +18,7 @@
 #include "repo_bson_assets.h"
 #include "repo_bson_builder.h"
 #include "repo/lib/datastructure/repo_uuid.h"
+#include <unordered_set>
 
 using namespace repo::core::model;
 
@@ -97,4 +98,18 @@ RepoAssets::operator RepoBSON() const
 bool RepoAssets::isEmpty() const
 {
 	return repoBundleFiles.empty() && repoJsonFiles.empty() && revisionId.isDefaultValue() && database.empty() && model.empty();
+}
+
+bool RepoSupermeshMetadata::operator==(const RepoSupermeshMetadata& other) const
+{
+	return numVertices == other.numVertices &&
+		numFaces == other.numFaces &&
+		numUVChannels == other.numUVChannels &&
+		numSubmeshes == other.numSubmeshes &&
+		numComponents == other.numComponents &&
+		primitive == other.primitive &&
+		min == other.min &&
+		max == other.max &&
+		std::unordered_set<std::string>(groups.begin(), groups.end()) ==
+		std::unordered_set<std::string>(other.groups.begin(), other.groups.end());
 }

--- a/bouncer/src/repo/core/model/bson/repo_bson_assets.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_assets.h
@@ -41,6 +41,14 @@ namespace repo {
 				size_t primitive;
 				repo::lib::RepoVector3D min;
 				repo::lib::RepoVector3D max;
+				std::vector<std::string> groups;
+
+				void addGrouping(const std::string& group)
+				{
+					if (!group.empty()) {
+						groups.push_back(group);
+					}
+				}
 			};
 
 			class REPO_API_EXPORT RepoAssets

--- a/bouncer/src/repo/core/model/bson/repo_bson_assets.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_assets.h
@@ -43,6 +43,24 @@ namespace repo {
 				repo::lib::RepoVector3D max;
 				std::vector<std::string> groups;
 
+				bool operator==(const RepoSupermeshMetadata& other) const
+				{
+					return numVertices == other.numVertices &&
+						numFaces == other.numFaces &&
+						numUVChannels == other.numUVChannels &&
+						numSubmeshes == other.numSubmeshes &&
+						numComponents == other.numComponents &&
+						primitive == other.primitive &&
+						min == other.min &&
+						max == other.max &&
+						groups == other.groups;
+				}
+
+				bool operator!=(const RepoSupermeshMetadata& other) const
+				{
+					return !(*this == other);
+				}
+
 				void addGrouping(const std::string& group)
 				{
 					if (!group.empty()) {

--- a/bouncer/src/repo/core/model/bson/repo_bson_assets.h
+++ b/bouncer/src/repo/core/model/bson/repo_bson_assets.h
@@ -43,18 +43,7 @@ namespace repo {
 				repo::lib::RepoVector3D max;
 				std::vector<std::string> groups;
 
-				bool operator==(const RepoSupermeshMetadata& other) const
-				{
-					return numVertices == other.numVertices &&
-						numFaces == other.numFaces &&
-						numUVChannels == other.numUVChannels &&
-						numSubmeshes == other.numSubmeshes &&
-						numComponents == other.numComponents &&
-						primitive == other.primitive &&
-						min == other.min &&
-						max == other.max &&
-						groups == other.groups;
-				}
+				bool operator==(const RepoSupermeshMetadata& other) const;
 
 				bool operator!=(const RepoSupermeshMetadata& other) const
 				{

--- a/bouncer/src/repo/core/model/bson/repo_node_streaming_mesh.cpp
+++ b/bouncer/src/repo/core/model/bson/repo_node_streaming_mesh.cpp
@@ -123,6 +123,9 @@ repo::core::model::StreamingMeshNode::StreamingMeshNode(const repo::core::model:
 	if (bson.hasField(REPO_NODE_MESH_LABEL_BOUNDING_BOX)) {
 		bounds = bson.getBoundsField(REPO_NODE_MESH_LABEL_BOUNDING_BOX);
 	}
+	if (bson.hasField(REPO_NODE_MESH_LABEL_GROUPING)) {
+		grouping = bson.getStringField(REPO_NODE_MESH_LABEL_GROUPING);
+	}
 }
 
 void repo::core::model::StreamingMeshNode::loadSupermeshingData(const repo::core::model::RepoBSON& bson, const std::vector<uint8_t>& buffer, const bool ignoreUVs)
@@ -136,6 +139,12 @@ void repo::core::model::StreamingMeshNode::loadSupermeshingData(const repo::core
 	supermeshingData = std::make_unique<SupermeshingData>(bson, buffer, ignoreUVs);
 }
 
+void repo::core::model::StreamingMeshNode::assertSupermeshingDataLoaded() {
+	if (!supermeshingDataLoaded()) {
+		throw repo::lib::RepoException("Tried to access supermesh geometry of StreamingMeshNode without loading geometry first.");
+	}
+}
+
 void repo::core::model::StreamingMeshNode::transformBounds(const repo::lib::RepoMatrix& transform)
 {
 	auto newMinBound = transform * bounds.min();
@@ -143,85 +152,43 @@ void repo::core::model::StreamingMeshNode::transformBounds(const repo::lib::Repo
 	bounds = repo::lib::RepoBounds(newMinBound, newMaxBound);
 }
 
-const repo::lib::RepoUUID repo::core::model::StreamingMeshNode::getUniqueId()
-{
-	if (supermeshingDataLoaded()) {
-		return supermeshingData->getUniqueId();
-	}
-	else {
-		repoError << "Tried to access supermesh geometry of StreamingMeshNode without loading geometry first. Empty returned.";
-		return repo::lib::RepoUUID();
-	}
+const repo::lib::RepoUUID repo::core::model::StreamingMeshNode::getUniqueId() {
+	assertSupermeshingDataLoaded();
+	return supermeshingData->getUniqueId();
 }
 
 const std::uint32_t repo::core::model::StreamingMeshNode::getNumLoadedFaces() {
-	if (supermeshingDataLoaded()) {
-		return supermeshingData->getNumFaces();
-	}
-	else {
-		repoError << "Tried to access supermesh geometry of StreamingMeshNode without loading geometry first. Empty returned.";
-		return 0;
-	}
+	assertSupermeshingDataLoaded();
+	return supermeshingData->getNumFaces();
 }
 
-const std::vector<repo::lib::repo_face_t>& repo::core::model::StreamingMeshNode::getLoadedFaces()
-{
-	if (supermeshingDataLoaded()) {
-		return supermeshingData->getFaces();
-	}
-	else {
-		repoError << "Tried to access supermesh geometry of StreamingMeshNode without loading geometry first. Empty returned.";
-		return emptyFace;
-	}
+const std::vector<repo::lib::repo_face_t>& repo::core::model::StreamingMeshNode::getLoadedFaces() {
+	assertSupermeshingDataLoaded();
+	return supermeshingData->getFaces();
 }
 
 const std::uint32_t repo::core::model::StreamingMeshNode::getNumLoadedVertices() {
-	if (supermeshingDataLoaded()) {
-		return supermeshingData->getNumVertices();
-	}
-	else {
-		repoError << "Tried to access supermesh geometry of StreamingMeshNode without loading geometry first. Empty returned.";
-		return 0;
-	}
+	assertSupermeshingDataLoaded();
+	return supermeshingData->getNumVertices();
 }
 
 const std::vector<repo::lib::RepoVector3D>& repo::core::model::StreamingMeshNode::getLoadedVertices() {
-	if (supermeshingDataLoaded()) {
-		return supermeshingData->getVertices();
-	}
-	else {
-		repoError << "Tried to access supermesh geometry of StreamingMeshNode without loading geometry first. Empty returned.";
-		return empty3D;
-	}
+	assertSupermeshingDataLoaded();
+	return supermeshingData->getVertices();
 }
 
 void repo::core::model::StreamingMeshNode::bakeLoadedMeshes(const repo::lib::RepoMatrix& transform) {
-	if (supermeshingDataLoaded()) {
-		supermeshingData->bakeMeshes(transform);
-	}
-	else {
-		repoError << "Tried to access supermesh geometry of StreamingMeshNode without loading geometry first. No action performed.";
-	}
+	assertSupermeshingDataLoaded();
+	return supermeshingData->bakeMeshes(transform);
 }
 
-const std::vector<repo::lib::RepoVector3D>& repo::core::model::StreamingMeshNode::getLoadedNormals()
-{
-	if (supermeshingDataLoaded()) {
-		return supermeshingData->getNormals();
-	}
-	else {
-		repoError << "Tried to access supermesh geometry of StreamingMeshNode without loading geometry first. Empty returned.";
-		return empty3D;
-	}
+const std::vector<repo::lib::RepoVector3D>& repo::core::model::StreamingMeshNode::getLoadedNormals() {
+	assertSupermeshingDataLoaded();
+	return supermeshingData->getNormals();
 }
 
 const std::vector<std::vector<repo::lib::RepoVector2D>>& repo::core::model::StreamingMeshNode::getLoadedUVChannelsSeparated()
 {
-	if (supermeshingDataLoaded()) {
-		return supermeshingData->getUVChannelsSeparated();
-	}
-	else {
-		repoError << "Tried to access supermesh geometry of StreamingMeshNode without loading geometry first. Empty returned.";
-		return emptyUV;
-	}
+	assertSupermeshingDataLoaded();
+	return supermeshingData->getUVChannelsSeparated();
 }

--- a/bouncer/src/repo/core/model/bson/repo_node_streaming_mesh.h
+++ b/bouncer/src/repo/core/model/bson/repo_node_streaming_mesh.h
@@ -99,13 +99,8 @@ namespace repo {
 				std::uint32_t numVertices = 0;
 				repo::lib::RepoUUID parent;
 				repo::lib::RepoBounds bounds;
-
+				std::string grouping;
 				std::unique_ptr<SupermeshingData> supermeshingData;
-
-				// Empty vectors as standins when the supermeshingData is not loaded
-				std::vector<repo::lib::repo_face_t> emptyFace;
-				std::vector<repo::lib::RepoVector3D> empty3D;
-				std::vector<std::vector<repo::lib::RepoVector2D>> emptyUV;
 
 			public:
 				StreamingMeshNode()
@@ -114,6 +109,12 @@ namespace repo {
 				}
 
 				StreamingMeshNode(const repo::core::model::RepoBSON& bson);
+
+				// StreamingMeshNode must have explicit move operators, even if default
+				// implementations, as we define explicit constructors above.
+
+				StreamingMeshNode(StreamingMeshNode&&) noexcept = default;
+				StreamingMeshNode& operator=(StreamingMeshNode&&) noexcept = default;
 
 				bool supermeshingDataLoaded() {
 					return supermeshingData != nullptr;
@@ -147,6 +148,11 @@ namespace repo {
 					return parent;
 				}
 
+				const std::string& getGrouping() const
+				{
+					return grouping;
+				}
+
 				void transformBounds(const repo::lib::RepoMatrix& transform);
 
 				// Requiring the supermeshing data to be loaded
@@ -166,6 +172,9 @@ namespace repo {
 				const std::vector<repo::lib::RepoVector3D>& getLoadedNormals();
 
 				const std::vector<std::vector<repo::lib::RepoVector2D>>& getLoadedUVChannelsSeparated();
+
+				private:
+					void assertSupermeshingDataLoaded(); // Throws if the supermeshing data is not loaded.
 			};
 		}
 	}

--- a/bouncer/src/repo/core/model/repo_model_global.h
+++ b/bouncer/src/repo/core/model/repo_model_global.h
@@ -225,7 +225,7 @@
 #define REPO_ASSETS_LABEL_NUMSUBMESHES	"numSubmeshes"
 #define REPO_ASSETS_LABEL_NUMCOMPONENTS	"numComponents"
 #define REPO_ASSETS_LABEL_METADATA      "metadata"
-#define REPO_ASSETS_LABEL_GROUP			"group"
+#define REPO_ASSETS_LABEL_GROUPS		"groups"
 
 //-----------------------------------------------------------------------------
 //

--- a/bouncer/src/repo/core/model/repo_model_global.h
+++ b/bouncer/src/repo/core/model/repo_model_global.h
@@ -225,6 +225,7 @@
 #define REPO_ASSETS_LABEL_NUMSUBMESHES	"numSubmeshes"
 #define REPO_ASSETS_LABEL_NUMCOMPONENTS	"numComponents"
 #define REPO_ASSETS_LABEL_METADATA      "metadata"
+#define REPO_ASSETS_LABEL_GROUP			"group"
 
 //-----------------------------------------------------------------------------
 //
@@ -239,3 +240,7 @@
 #define REPO_FILTER_TAG_TRANSPARENT		"materialProperties.isTransparent"
 #define REPO_FILTER_TAG_TEXTURE_ID		"materialProperties.textureId"
 #define REPO_FILTER_TAG_NORMALS			"_blobRef.elements.normals"
+
+// Special grouping fields
+
+#define REPO_METADATA_GROUPING_FLOOR	"Asite 3DRepo::Floor"

--- a/bouncer/src/repo/lib/repo_hash_combine.h
+++ b/bouncer/src/repo/lib/repo_hash_combine.h
@@ -1,0 +1,32 @@
+/**
+*  Copyright (C) 2015 3D Repo Ltd
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Affero General Public License as
+*  published by the Free Software Foundation, either version 3 of the
+*  License, or (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Affero General Public License for more details.
+*
+*  You should have received a copy of the GNU Affero General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#define HASH_GOLDEN_RATIO 0x9e3779b9
+
+/*
+* Convenience template for combining std::hash values. From boost::hash_combine.
+*/
+
+namespace repo {
+    namespace lib {
+        template <typename T> inline void hash_combine(size_t& seed, T const& v) {
+            seed ^= std::hash<T>()(v) + HASH_GOLDEN_RATIO + (seed << 6) + (seed >> 2);
+        }
+    }
+}

--- a/bouncer/src/repo/lib/repo_hash_combine.h
+++ b/bouncer/src/repo/lib/repo_hash_combine.h
@@ -1,5 +1,5 @@
 /**
-*  Copyright (C) 2015 3D Repo Ltd
+*  Copyright (C) 2026 3D Repo Ltd
 *
 *  This program is free software: you can redistribute it and/or modify
 *  it under the terms of the GNU Affero General Public License as

--- a/bouncer/src/repo/lib/repo_hash_combine.h
+++ b/bouncer/src/repo/lib/repo_hash_combine.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <functional>
+
 /*
 * Convenience template for combining std::hash values. From boost::hash_combine.
 */

--- a/bouncer/src/repo/lib/repo_hash_combine.h
+++ b/bouncer/src/repo/lib/repo_hash_combine.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#define HASH_GOLDEN_RATIO 0x9e3779b9
-
 /*
 * Convenience template for combining std::hash values. From boost::hash_combine.
 */
@@ -26,7 +24,10 @@
 namespace repo {
     namespace lib {
         template <typename T> inline void hash_combine(size_t& seed, T const& v) {
-            seed ^= std::hash<T>()(v) + HASH_GOLDEN_RATIO + (seed << 6) + (seed >> 2);
+            // 0x9e3779b9 is the fractional part of the Golden Ratio which is
+			// often used in hashing functions due to its good equidistribution
+			// properties, including Boost's hash_combine on which this is based.
+            seed ^= std::hash<T>()(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
         }
     }
 }

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_nwd.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_nwd.cpp
@@ -24,6 +24,7 @@
 #include "repo/manipulator/modelconvertor/import/odaHelper/repo_mesh_builder.h"
 #include "repo/core/model/bson/repo_node_transformation.h"
 #include "repo/core/model/bson/repo_bson_factory.h"
+#include "repo/lib/datastructure/repo_variant_utils.h"
 
 #include <repo_log.h>
 
@@ -926,6 +927,14 @@ OdResult traverseSceneGraph(OdNwModelItemPtr pNode, RepoNwTraversalContext conte
 
 			context.parentNode = context.sceneBuilder->addNode(RepoBSONFactory::makeTransformationNode({}, levelName, { context.parentNode->getSharedID() }));
 
+			// To match the plug-in, and ensure metadata ends up in the right place for
+			// the benefit of smart groups, node properties are overridden with their
+			// parent's metadata
+			std::unordered_map<std::string, repo::lib::RepoVariant> merged = metadata;
+			for (auto p : context.parentMetadata) {
+				merged[p.first] = p.second;
+			}
+
 			// GetIcon distinguishes the type of node. This corresponds to the icon seen in
 			// the Selection Tree View in Navisworks.
 			// https://docs.opendesign.com/bimnv/OdNwModelItem__getIcon@const.html
@@ -935,14 +944,27 @@ OdResult traverseSceneGraph(OdNwModelItemPtr pNode, RepoNwTraversalContext conte
 			if (pNode->getIcon() == NwModelItemIcon::LAYER)
 			{
 				context.layer = pNode;
-			}
 
-			// To match the plug-in, and ensure metadata ends up in the right place for
-			// the benefit of smart groups, node properties are overridden with their
-			// parent's metadata
-			std::unordered_map<std::string, repo::lib::RepoVariant> merged = metadata;
-			for (auto p : context.parentMetadata) {
-				merged[p.first] = p.second;
+				// For layers, check if we need to add the magic floor metadata. This applies
+				// to Rvt and Ifc partitions - both of which will create Layer's for floors.
+				//
+				// This magic parameter should be applied directly to the node's - it should
+				// not be inherited like the other parameters above. Hence we check the map
+				// extracted from the node (metadata) but write to map that is written to the
+				// db (merged).
+				{
+					auto it = metadata.find("Item::Internal Type"); // For Rvt files, look for the LcRevitLayer type
+					if (it != metadata.end() && boost::apply_visitor(repo::lib::StringConversionVisitor(), it->second) == "LcRevitLayer") {
+						merged[REPO_METADATA_GROUPING_FLOOR] = levelName;
+					}
+				}
+
+				{
+					auto it = metadata.find("Element::IfcClass"); // For Ifc files, look for the IfcBuildingStorey class
+					if (it != metadata.end() && boost::apply_visitor(repo::lib::StringConversionVisitor(), it->second) == "IfcBuildingStorey") {
+						merged[REPO_METADATA_GROUPING_FLOOR] = levelName;
+					}
+				}
 			}
 
 			context.sceneBuilder->addNode(RepoBSONFactory::makeMetaDataNode(merged, context.parentNode->getName(), { context.parentNode->getSharedID() }));

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/data_processor_rvt.cpp
@@ -302,7 +302,11 @@ void DataProcessorRvt::draw(const OdGiDrawable* pDrawable)
 
 			// These methods create the transformation nodes on-demand
 
-			collector->createLayer(levelName, levelName, {}, {});
+			if (collector->createLayer(levelName, levelName, {}, {})) {
+				repo::core::model::RepoRef::Metadata meta;
+				meta[REPO_METADATA_GROUPING_FLOOR] = levelName; // This is the magic tag used to indicate this branch should form a level grouping, if that feature is used
+				collector->setMetadata(levelName, meta);
+			}
 
 			// This call does not necessarily update the transform, so make sure to get
 			// the transform explicitly when processing the meshes.

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.cpp
@@ -93,7 +93,7 @@ void GeometryCollector::popDrawContext(Context* ctx)
 	}
 }
 
-void GeometryCollector::createLayer(std::string id, std::string name, std::string parentId, const repo::lib::RepoMatrix& transform)
+bool GeometryCollector::createLayer(std::string id, std::string name, std::string parentId, const repo::lib::RepoMatrix& transform)
 {
 	if (!hasLayer(id)) {
 		auto parentSharedId = rootNodeId;
@@ -111,7 +111,11 @@ void GeometryCollector::createLayer(std::string id, std::string name, std::strin
 		}
 
 		sceneBuilder->addNode(node);
+
+		return true;
 	}
+
+	return false;
 }
 
 repo::lib::RepoMatrix GeometryCollector::getLayerTransform(std::string id)

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/geometry_collector.h
@@ -43,9 +43,11 @@ namespace repo {
 					/*
 					* Declares a new entry in the tree that can be accessed by an arbitrary
 					* Id (instead of a RepoUUID). If parentId is empty, the layer will be
-					* created under the root node.
+					* created under the root node. Returns true if the layer was newly created
+					* or false if it already existed. If the layer exists, the name, parent and
+					* transform will be unchanged/ignored.
 					*/
-					void createLayer(std::string id, std::string name, std::string parentId, const repo::lib::RepoMatrix& transform);
+					bool createLayer(std::string id, std::string name, std::string parentId, const repo::lib::RepoMatrix& transform);
 
 					/*
 					* True if the layer with the id was created with createLayer. createLayer

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_config.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_config.cpp
@@ -31,7 +31,8 @@ ModelImportConfig::ModelImportConfig() :
 	targetUnits(ModelUnits::UNKNOWN),
 	revisionId(repo::lib::RepoUUID::defaultValue),
 	lod(0),
-	numThreads(0)
+	numThreads(0),
+	splitByFloor(true)
 {}
 
 ModelImportConfig::ModelImportConfig(
@@ -74,5 +75,6 @@ std::string ModelImportConfig::prettyPrint()
 		+ " revisionId: " + revisionId.toString()
 		+ " num threads: " + std::to_string(numThreads)
 		+ " view name: " + (viewName.empty() ? "NONE" : viewName)
+		+ " split by floor: " + (splitByFloor ? "true" : "false")
 	);
 }

--- a/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_config.h
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/repo_model_import_config.h
@@ -46,6 +46,7 @@ namespace repo {
 				int numThreads;
 				std::string viewName;
 				std::string viewStyle;
+				bool splitByFloor;
 
 				ModelImportConfig();
 

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
@@ -56,7 +56,8 @@ MultipartOptimizer::MultipartOptimizer(
 	repo::manipulator::modelconvertor::AbstractModelExport* exporter
 ):
 	handler(handler),
-	exporter(exporter)
+	exporter(exporter),
+	splitByFloor(false)
 {
 }
 
@@ -162,7 +163,9 @@ MultipartOptimizer::TransformMap MultipartOptimizer::getAllTransforms(
 	}
 
 	// Find all branch groupings using magic metadata fields.
-	applyBranchGroups(transformMap, database, collection, revId);
+	if (splitByFloor) {
+		applyBranchGroups(transformMap, database, collection, revId);
+	}
 
 	if (rootNode.isEmpty()) {
 		throw repo::lib::RepoException("getAllTransforms; no root node found.");

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
@@ -26,12 +26,15 @@
 
 #include "repo_optimizer_multipart.h"
 #include "repo/core/model/bson/repo_bson_factory.h"
+#include "repo/core/model/repo_model_global.h"
+#include "repo/lib/repo_hash_combine.h"
 
 #include <algorithm>
 #include <chrono>
 
 using namespace repo::lib;
 using namespace repo::manipulator::modeloptimizer;
+using namespace repo::core::handler::database;
 
 auto defaultGraph = repo::core::model::RepoScene::GraphType::DEFAULT;
 
@@ -48,102 +51,57 @@ static const size_t REPO_MODEL_LOW_CLUSTERING_RATIO = 0.2f;
 
 #define CHRONO_DURATION(start) std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start).count()
 
-bool MultipartOptimizer::processScene(
+MultipartOptimizer::MultipartOptimizer(
+	repo::core::handler::AbstractDatabaseHandler* handler,
+	repo::manipulator::modelconvertor::AbstractModelExport* exporter
+):
+	handler(handler),
+	exporter(exporter)
+{
+}
+
+void MultipartOptimizer::processScene(
 	std::string database,
 	std::string collection,
-	repo::lib::RepoUUID revId,
-	repo::core::handler::AbstractDatabaseHandler *handler,
-	repo::manipulator::modelconvertor::AbstractModelExport* exporter)
+	repo::lib::RepoUUID revId)
 {
 	// Getting Transforms
 	repoInfo << "Getting Transforms";
-	auto transformMap = getAllTransforms(handler, database, collection, revId);
+	auto transformMap = getAllTransforms(database, collection, revId);
 
 	// Get lookup map for material properties
 	repoInfo << "Getting Materials";
-	auto matPropMap = getAllMaterials(handler, database, collection, revId);
-
-	// Get all groupings
-	repoInfo << "Getting Groupings";
-	auto groupings = getAllGroupings(handler, database, collection, revId);
-	repoInfo << "Found " << groupings.size() << " groupings";
+	auto matPropMap = getAllMaterials(database, collection, revId);
 
 	// Create jobs
 	repoInfo << "Creating Processing Jobs";
 	std::vector<ProcessingJob> jobs;
-	for (auto grouping : groupings) {
 
-		// Jobs for opaque, prim 2
-		{
-			std::string description = "Grouping: " + grouping + ", Opaque, Primitive 2, No Normals";			
-			jobs.push_back(createUntexturedJob(description, revId, 2, grouping, true, false));
-		}
-		{
-			std::string description = "Grouping: " + grouping + ", Opaque, Primitive 2, Normals";
-			jobs.push_back(createUntexturedJob(description, revId, 2, grouping, true, true));
-		}
+	jobs.push_back(createUntexturedJob(revId, 2, false, false));
+	jobs.push_back(createUntexturedJob(revId, 2, false, true));
+	jobs.push_back(createUntexturedJob(revId, 2, true, false));
+	jobs.push_back(createUntexturedJob(revId, 2, true, true));
+	
+	jobs.push_back(createUntexturedJob(revId, 3, false, false));
+	jobs.push_back(createUntexturedJob(revId, 3, false, true));
+	jobs.push_back(createUntexturedJob(revId, 3, true, false));
+	jobs.push_back(createUntexturedJob(revId, 3, true, true));
+	
+	// Get Texture IDs
+	repoInfo << "Getting all texture Ids";
+	auto texIds = getAllTextureIds(database, collection, revId);
 
-		// Jobs for opaque, prim 3
-		{
-			std::string description = "Grouping: " + grouping + ", Opaque, Primitive 3, No Normals";
-			jobs.push_back(createUntexturedJob(description, revId, 3, grouping, true, false));
-		}
-		{
-			std::string description = "Grouping: " + grouping + ", Opaque, Primitive 3, Normals";
-			jobs.push_back(createUntexturedJob(description, revId, 3, grouping, true, true));
-		}
+	// Create jobs for each texture group
+	for (auto texId : texIds) {
+		// One cannot map a texture to a line, however, customers can assign materials with textures to lines
+		// so we need to be able to process them.
+		jobs.push_back(createTexturedJob(revId, 2, false, texId));
+		jobs.push_back(createTexturedJob(revId, 2, true, texId));
 
-		// Jobs for transparent, prim 2
-		{
-			std::string description = "Grouping: " + grouping + ", Transparent, Primitive 2, No Normals";
-			jobs.push_back(createUntexturedJob(description, revId, 2, grouping, false, false));
-		}
-		{
-			std::string description = "Grouping: " + grouping + ", Transparent, Primitive 2, Normals";
-			jobs.push_back(createUntexturedJob(description, revId, 2, grouping, false, true));
-		}
-
-		// Jobs for transparent, prim 3
-		{
-			std::string description = "Grouping: " + grouping + ", Transparent, Primitive 3, No Normals";
-			jobs.push_back(createUntexturedJob(description, revId, 3, grouping, false, false));
-		}
-		{
-			std::string description = "Grouping: " + grouping + ", Transparent, Primitive 3, Normals";
-			jobs.push_back(createUntexturedJob(description, revId, 3, grouping, false, true));
-		}
-
-		// Get Texture IDs
-		repoInfo << "Getting all texture Ids for grouping " << grouping;
-		auto texIds = getAllTextureIds(handler, database, collection, revId, grouping);
-
-		// Create jobs for each texture group
-		for (auto texId : texIds) {
-
-			// Jobs for textured, prim 2
-			// One cannot map a texture to a line, however, customers can assign materials with textures to lines
-			// so we need to be able to process them.
-			{
-				std::string description = "Grouping: " + grouping + ", Textured " + texId.toString() + " , Primitive 2, No Normals";
-				jobs.push_back(createTexturedJob(description, revId, 2, grouping, false, texId));
-			}
-			{
-				std::string description = "Grouping: " + grouping + ", Textured " + texId.toString() + " , Primitive 2, Normals";
-				jobs.push_back(createTexturedJob(description, revId, 2, grouping, true, texId));
-			}
-
-			// Job for textured, prim 3
-			{
-				std::string description = "Grouping: " + grouping + ", Textured " + texId.toString() + " , Primitive 3, No Normals";
-				jobs.push_back(createTexturedJob(description, revId, 3, grouping, false, texId));
-			}
-			{
-				std::string description = "Grouping: " + grouping + ", Textured " + texId.toString() + " , Primitive 3, Normals";
-				jobs.push_back(createTexturedJob(description, revId, 3, grouping, true, texId));
-			}
-		}
+		jobs.push_back(createTexturedJob(revId, 3, false, texId));
+		jobs.push_back(createTexturedJob(revId, 3, true, texId));
 	}
-
+	
 	// Process jobs
 	repoInfo << "Processing Jobs";
 
@@ -151,8 +109,6 @@ bool MultipartOptimizer::processScene(
 		clusterAndSupermesh(
 			database,
 			collection,
-			handler,
-			exporter,
 			transformMap,
 			matPropMap,
 			job);
@@ -160,18 +116,14 @@ bool MultipartOptimizer::processScene(
 
 	// Finalise export
 	exporter->finalise();
-
-	return true;
 }
 
-std::unordered_map<repo::lib::RepoUUID, repo::lib::RepoMatrix, repo::lib::RepoUUIDHasher> MultipartOptimizer::getAllTransforms(
-	repo::core::handler::AbstractDatabaseHandler *handler,
+MultipartOptimizer::TransformMap MultipartOptimizer::getAllTransforms(
 	const std::string &database,
 	const std::string &collection,
 	const repo::lib::RepoUUID &revId
 )
 {
-
 	repo::core::handler::database::query::RepoQueryBuilder filter;
 	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_REVISION_ID, revId));
 	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_LABEL_TYPE, std::string(REPO_NODE_TYPE_TRANSFORMATION)));
@@ -185,55 +137,104 @@ std::unordered_map<repo::lib::RepoUUID, repo::lib::RepoMatrix, repo::lib::RepoUU
 	auto sceneCollection = collection + "." + REPO_COLLECTION_SCENE;
 	auto cursor = handler->findCursorByCriteria(database, sceneCollection, filter, projection);
 
-	std::unordered_map<repo::lib::RepoUUID, repo::lib::RepoMatrix, repo::lib::RepoUUIDHasher> transformMap;
+	TransformMap transformMap;
 
-	if (cursor) {
-		repo::core::model::RepoBSON rootNode;
-		std::unordered_map<repo::lib::RepoUUID, std::vector<repo::core::model::RepoBSON>, repo::lib::RepoUUIDHasher> childNodeMap;
-		for (auto bson : (*cursor)) {
-			if (bson.hasField(REPO_NODE_LABEL_PARENTS)) {
-				auto parentId = bson.getUUIDFieldArray(REPO_NODE_LABEL_PARENTS)[0];
+	repo::core::model::RepoBSON rootNode;
+	std::unordered_map<repo::lib::RepoUUID, std::vector<repo::core::model::RepoBSON>, repo::lib::RepoUUIDHasher> childNodeMap;
+	for (auto bson : (*cursor)) {
+		if (bson.hasField(REPO_NODE_LABEL_PARENTS)) {
+			auto parentId = bson.getUUIDFieldArray(REPO_NODE_LABEL_PARENTS)[0];
 
-				if (childNodeMap.contains(parentId)) {
-					childNodeMap.at(parentId).push_back(bson);
-				}
-				else {
-					auto children = std::vector<repo::core::model::RepoBSON>{ bson };
-					childNodeMap.insert({ parentId, children });
-				}
+			if (childNodeMap.contains(parentId)) {
+				childNodeMap.at(parentId).push_back(bson);
 			}
 			else {
-				rootNode = bson;
+				auto children = std::vector<repo::core::model::RepoBSON>{bson};
+				childNodeMap.insert({parentId, children});
 			}
 		}
-		if (rootNode.isEmpty()) {
-			repoWarning << "getAllTransforms; no transformations returned by database query.";
-		}
 		else {
-			traverseTransformTree(rootNode, childNodeMap, transformMap);
+			rootNode = bson;
 		}
-	}
-	else {
-		repoWarning << "getAllTransforms; getting cursor was not successful; no transforms in output map";
+
+		// Pre-create all the transform info nodes
+		transformMap.insert({bson.getUUIDField(REPO_NODE_LABEL_SHARED_ID), {}});
 	}
 
+	// Find all branch groupings using magic metadata fields.
+	applyBranchGroups(transformMap, database, collection, revId);
+
+	if (rootNode.isEmpty()) {
+		throw repo::lib::RepoException("getAllTransforms; no root node found.");
+	}
+
+	traverseTransformTree(rootNode, childNodeMap, transformMap);
+
 	return transformMap;
+}
+
+void MultipartOptimizer::applyBranchGroups(
+	TransformMap& transforms, 
+	const std::string& database,
+	const std::string& collection, 
+	const repo::lib::RepoUUID &revId)
+{
+	// In the future we may extend this method to support user-defined queries,
+	// but for now we split based on the presence of the magic metadata field.
+
+	query::RepoQueryBuilder filter;
+	filter.append(query::Eq(REPO_NODE_REVISION_ID, revId));
+	filter.append(query::Eq(REPO_NODE_LABEL_TYPE, std::string(REPO_NODE_TYPE_METADATA)));
+	filter.append(query::ArrayContains(REPO_NODE_LABEL_METADATA, query::Eq(REPO_NODE_LABEL_META_KEY, std::string(REPO_METADATA_GROUPING_FLOOR))));
+
+	repo::core::handler::database::query::RepoProjectionBuilder projection;
+	projection.excludeField(REPO_NODE_LABEL_ID);
+	projection.includeField(REPO_NODE_LABEL_SHARED_ID);
+	projection.includeField(REPO_NODE_LABEL_PARENTS);
+	projection.includeField(REPO_NODE_LABEL_METADATA);
+
+	auto sceneCollection = collection + "." + REPO_COLLECTION_SCENE;
+	auto cursor = handler->findCursorByCriteria(database, sceneCollection, filter, projection);
+
+	std::unordered_map<std::string, BranchGroup*> branchGroupsByTag;
+
+	for (auto bson : (*cursor)) {
+		auto metadataNode = repo::core::model::MetadataNode(bson);
+		auto& metadata = metadataNode.getAllMetadata();
+		auto& variant = metadata.at(REPO_METADATA_GROUPING_FLOOR);
+		auto value = boost::get<std::string>(variant);
+
+		auto& groupPtr = branchGroupsByTag[value];
+		if (!groupPtr) {
+			groupPtr = new BranchGroup();
+			groupPtr->name = value;
+		}
+
+		for (auto& parent : metadataNode.getParentIDs()) {
+			auto transformIt = transforms.find(parent);
+			if (transformIt != transforms.end()) {
+				transformIt->second.branch = groupPtr;
+			}
+		}
+	}
 }
 
 void MultipartOptimizer::traverseTransformTree(
 	const repo::core::model::RepoBSON &root,
 	const std::unordered_map<repo::lib::RepoUUID, std::vector<repo::core::model::RepoBSON>,	repo::lib::RepoUUIDHasher> &childNodeMap,
-	std::unordered_map<repo::lib::RepoUUID,	repo::lib::RepoMatrix, repo::lib::RepoUUIDHasher> &transforms)
+	TransformMap &transforms)
 {
+	/*
+	* This method will bake the transform tree, updating each entry in transforms
+	* with its final state after performing a depth-first evaluation.
+	*/
 
 	// Create stacks for the nodes and the matrices
-	std::stack<std::pair<repo::core::model::RepoBSON, repo::lib::RepoMatrix>> stack;
+	std::stack<std::pair<repo::core::model::RepoBSON, TransformInfo>> stack;
 
-	// Starting matrix
-	repo::lib::RepoMatrix identity;
-
-	// Push starting node and starting matrix on the stack
-	stack.push({ root, identity });
+	// Push starting node onto the stack. The default initialiser will create an
+	// identity matrix and a null branch group.
+	stack.push({root, {}});
 
 	// DFS traversal of the transformation tree, summing up the matrices along the way
 	while (!stack.empty()) {
@@ -242,32 +243,34 @@ void MultipartOptimizer::traverseTransformTree(
 		auto top = stack.top();
 		stack.pop();
 
-		auto topBson = top.first;
-		auto topMat = top.second;
+		auto bson = top.first;
+		auto parentInfo = top.second;
 
 		// Get node information
-		auto nodeId = topBson.getUUIDField(REPO_NODE_LABEL_SHARED_ID);
-		auto matrix = topBson.getMatrixField(REPO_NODE_LABEL_MATRIX);
+		auto nodeId = bson.getUUIDField(REPO_NODE_LABEL_SHARED_ID);
+		auto matrix = bson.getMatrixField(REPO_NODE_LABEL_MATRIX);
+		
+		auto& info = transforms.at(nodeId); // Transform to update
 
-		// Apply the node's trnsaformation
-		auto newMat = topMat * matrix;
+		// Update the node's transformation
+		info.matrix = parentInfo.matrix * matrix;
 
-		// Insert the transform for children of this node into the map
-		transforms.insert({ nodeId, newMat });
+		// Inherit the branch group
+		if (!info.branch) {
+			info.branch = parentInfo.branch;
+		}
 
 		// if this node has other transforms as children, push them on the stack
 		if (childNodeMap.contains(nodeId)) {			
 			auto children = childNodeMap.at(nodeId);
 			for (auto child : children) {
-				stack.push({ child, newMat });
+				stack.push({ child, info });
 			}
 		}
-
 	}
 }
 
 MultipartOptimizer::MaterialPropMap MultipartOptimizer::getAllMaterials(
-	repo::core::handler::AbstractDatabaseHandler *handler,
 	const std::string &database,
 	const std::string &collection,
 	const repo::lib::RepoUUID &revId)
@@ -296,58 +299,15 @@ MultipartOptimizer::MaterialPropMap MultipartOptimizer::getAllMaterials(
 	return matMap;
 }
 
-std::set<std::string> MultipartOptimizer::getAllGroupings(
-	repo::core::handler::AbstractDatabaseHandler* handler,
-	const std::string& database,
-	const std::string& collection,
-	const repo::lib::RepoUUID& revId
-) {
-	// Create filter
-	repo::core::handler::database::query::RepoQueryBuilder filter;
-	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_REVISION_ID, revId));
-	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_LABEL_TYPE, std::string(REPO_NODE_TYPE_MESH)));
-	filter.append(repo::core::handler::database::query::Exists(REPO_NODE_MESH_LABEL_GROUPING, true));
-
-	repo::core::handler::database::query::RepoProjectionBuilder projection;
-	projection.excludeField(REPO_NODE_LABEL_ID);
-	projection.includeField(REPO_NODE_MESH_LABEL_GROUPING);
-
-	std::set<std::string> groupings;
-
-	// Add default grouping
-	groupings.insert("");
-
-	auto sceneCollection = collection + "." + REPO_COLLECTION_SCENE;
-	auto cursor = handler->findCursorByCriteria(database, sceneCollection, filter, projection);
-
-	if (cursor) {
-		for (auto document : (*cursor)) {
-			auto bson = repo::core::model::RepoBSON(document);
-			groupings.insert(bson.getStringField(REPO_NODE_MESH_LABEL_GROUPING));
-		}
-	}
-	else {
-		repoWarning << "getAllGroupings; getting cursor was not successful; no groupings from db in output vector";
-	}
-
-	return groupings;
-}
-
 std::vector<repo::lib::RepoUUID> MultipartOptimizer::getAllTextureIds(
-	repo::core::handler::AbstractDatabaseHandler *handler,
 	const std::string &database,
 	const std::string &collection,
-	const repo::lib::RepoUUID &revId,
-	const std::string& grouping) {
+	const repo::lib::RepoUUID &revId) {
 
 	// Create filter
 	repo::core::handler::database::query::RepoQueryBuilder filter;
 	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_REVISION_ID, revId));
 	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_LABEL_TYPE, std::string(REPO_NODE_TYPE_TEXTURE)));
-	if (!grouping.empty())
-		filter.append(repo::core::handler::database::query::Eq(REPO_NODE_MESH_LABEL_GROUPING, grouping));
-	else
-		filter.append(repo::core::handler::database::query::Exists(REPO_NODE_MESH_LABEL_GROUPING, false));
 
 	repo::core::handler::database::query::RepoProjectionBuilder projection;
 	projection.includeField(REPO_NODE_LABEL_ID);
@@ -371,49 +331,43 @@ std::vector<repo::lib::RepoUUID> MultipartOptimizer::getAllTextureIds(
 }
 
 MultipartOptimizer::ProcessingJob repo::manipulator::modeloptimizer::MultipartOptimizer::createUntexturedJob(
-	const std::string &description,
 	const repo::lib::RepoUUID &revId,
 	const int primitive,
-	const std::string &grouping,
 	const bool isOpaque,
 	const bool hasNormals)
 {
 	// Create filter
 	repo::core::handler::database::query::RepoQueryBuilder filter;
+	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_LABEL_TYPE, REPO_NODE_TYPE_MESH));
 	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_REVISION_ID, revId));
 	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_MESH_LABEL_PRIMITIVE, primitive));
-	if (!grouping.empty())
-		filter.append(repo::core::handler::database::query::Eq(REPO_NODE_MESH_LABEL_GROUPING, grouping));
-	else
-		filter.append(repo::core::handler::database::query::Exists(REPO_NODE_MESH_LABEL_GROUPING, false));
 	if (isOpaque)
 		filter.append(repo::core::handler::database::query::Eq(REPO_FILTER_TAG_OPAQUE, true));
 	else
 		filter.append(repo::core::handler::database::query::Eq(REPO_FILTER_TAG_TRANSPARENT, true));
 	filter.append(repo::core::handler::database::query::Exists(REPO_FILTER_TAG_NORMALS, hasNormals));
 
+	std::string description = "Untextured Job - Primitive: " + std::to_string(primitive) + "; " + (isOpaque ? "Opaque" : "Transparent") + "; " + (hasNormals ? "Has Normals" : "No Normals");
+
 	// Create job
 	return ProcessingJob({ description, filter, {} });
 }
 
 MultipartOptimizer::ProcessingJob repo::manipulator::modeloptimizer::MultipartOptimizer::createTexturedJob(
-	const std::string &description,
 	const repo::lib::RepoUUID &revId,
 	const int primitive,
-	const std::string &grouping,
 	const bool hasNormals,
 	const repo::lib::RepoUUID &texId)
 {
 	// Create filter
 	repo::core::handler::database::query::RepoQueryBuilder filter;
+	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_LABEL_TYPE, REPO_NODE_TYPE_MESH));
 	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_REVISION_ID, revId));
 	filter.append(repo::core::handler::database::query::Eq(REPO_FILTER_TAG_TEXTURE_ID, texId));
 	filter.append(repo::core::handler::database::query::Eq(REPO_NODE_MESH_LABEL_PRIMITIVE, primitive));
-	if (!grouping.empty())
-		filter.append(repo::core::handler::database::query::Eq(REPO_NODE_MESH_LABEL_GROUPING, grouping));
-	else
-		filter.append(repo::core::handler::database::query::Exists(REPO_NODE_MESH_LABEL_GROUPING, false));
 	filter.append(repo::core::handler::database::query::Exists(REPO_FILTER_TAG_NORMALS, hasNormals));
+
+	std::string description = "Textured Job - Texture: " + texId.toString() + "; Primitive: " + std::to_string(primitive) + "; " + (hasNormals ? "Has Normals" : "No Normals");
 
 	// Create job
 	return ProcessingJob({ description, filter, texId });
@@ -422,8 +376,6 @@ MultipartOptimizer::ProcessingJob repo::manipulator::modeloptimizer::MultipartOp
 void MultipartOptimizer::clusterAndSupermesh(
 	const std::string &database,
 	const std::string &collection,
-	repo::core::handler::AbstractDatabaseHandler *handler,
-	repo::manipulator::modelconvertor::AbstractModelExport *exporter,
 	const TransformMap& transformMap,
 	const MaterialPropMap& matPropMap,
 	const MultipartOptimizer::ProcessingJob &job
@@ -437,64 +389,86 @@ void MultipartOptimizer::clusterAndSupermesh(
 	projection.includeField(REPO_NODE_MESH_LABEL_BOUNDING_BOX);
 	projection.includeField(REPO_NODE_MESH_LABEL_VERTICES_COUNT);
 	projection.includeField(REPO_NODE_LABEL_PARENTS);
+	projection.includeField(REPO_NODE_MESH_LABEL_GROUPING);
 
 	// Get cursor
 	auto sceneCollection = collection + "." + REPO_COLLECTION_SCENE;
 	auto cursor = handler->findCursorByCriteria(database, sceneCollection, job.filter, projection);
 
-	// iterate cursor and pack outcomes in lightweight mesh node structure
-	std::vector<repo::core::model::StreamingMeshNode> nodes;
-	if (cursor) {
-		for (auto bson : (*cursor)) {
-			nodes.push_back(repo::core::model::StreamingMeshNode(bson));
+	// Currently we support two levels of grouping when supermeshing, the
+	// MeshNode branch group, and the group tag of the Mesh itself.
+
+	struct group {
+		std::string mesh;
+		BranchGroup* branch;
+	};
+
+	struct group_hash {
+		std::size_t operator()(const group& k) const {
+			size_t h = 0;
+			hash_combine(h, k.mesh);
+			hash_combine(h, k.branch);
+			return h;
 		}
-	}
-	else {
-		repoWarning << "clusterAndSupermesh; getting cursor was not successful; no nodes filtered for processing";
+	};
+
+	struct group_equal {
+		bool operator()(const group& a, const group& b) const {
+			return a.mesh == b.mesh && a.branch == b.branch;
+		}
+	};
+
+	std::unordered_map<
+		group,
+		std::vector<repo::core::model::StreamingMeshNode>,
+		group_hash,
+		group_equal
+	> groups;
+
+	// iterate cursor and pack outcomes in lightweight mesh node structure
+	for (auto bson : (*cursor)) {
+		repo::core::model::StreamingMeshNode node(bson);
+		auto transform = transformMap.at(node.getParent());
+
+		// Transform bounds
+		node.transformBounds(transform.matrix);
+
+		// Get grouping
+		auto& group = groups[{ node.getGrouping(), transform.branch }];
+		group.emplace_back(std::move(node));
 	}
 
-	// Check whether there are any nodes in this group
-	if (nodes.size() == 0) {
-		repoInfo << "No nodes to process in this group. Returning.";
+	if (groups.size() == 0) {
+		repoInfo << "No groups to process for this job. Returning.";
 		return;
 	}
 
-	// Transform bounds before clustering
-	for (auto& node : nodes) {
-		auto bounds = node.getBoundingBox();
+	// Process the mesh groups
+	for (auto& group : groups) {
+		auto& branchGroup = group.first.branch;
+		auto& nodes = group.second;
 
-		// Transform bounds
-		auto parentId = node.getParent();
+		// Cluster the mesh nodes
+		repoInfo << "Clustering Nodes";
+		auto clusters = clusterMeshNodes(nodes);
 
-		if (transformMap.contains(parentId)) {
-			auto transMat = transformMap.at(node.getParent());
-			node.transformBounds(transMat);
-		}
-		else {
-			repoWarning << "clusterAndSupermesh; current node " << node.getSharedId().toString() << " has no transform parents; this should not happen; malformed file?";
-		}
+		// Create Supermeshes from the clusters
+		repoInfo << "Creating Supermeshes from clustered Nodes";
+		auto texId = job.isTexturedJob() ? job.texId : repo::lib::RepoUUID();
+		auto tag = branchGroup ? branchGroup->name : std::string(); // Resource groups never contribute to the name, only branch groups
+		createSuperMeshes(database, collection, transformMap, matPropMap, nodes, clusters, texId, tag);
 	}
-
-	// Cluster the mesh nodes
-	repoInfo << "Clustering Nodes";
-	auto clusters = clusterMeshNodes(nodes);
-
-	// Create Supermeshes from the clusters
-	repoInfo << "Creating Supermeshes from clustered Nodes";
-	auto texId = job.isTexturedJob() ? job.texId : repo::lib::RepoUUID();
-	createSuperMeshes(database, collection, handler, exporter, transformMap, matPropMap, nodes, clusters, texId);
 }
 
 void repo::manipulator::modeloptimizer::MultipartOptimizer::createSuperMeshes(
 	const std::string &database,
 	const std::string &collection,
-	repo::core::handler::AbstractDatabaseHandler *handler,
-	repo::manipulator::modelconvertor::AbstractModelExport *exporter,
 	const TransformMap& transformMap,
 	const MaterialPropMap& matPropMap,
 	std::vector<repo::core::model::StreamingMeshNode>& meshNodes,
 	const std::vector<std::vector<int>>& clusters,
-	const repo::lib::RepoUUID &texId)
+	const repo::lib::RepoUUID &texId,
+	const std::string& namedGrouping)
 {
 	// Get blobHandler
 	auto sceneCollection = collection + "." + REPO_COLLECTION_SCENE;
@@ -556,14 +530,8 @@ void repo::manipulator::modeloptimizer::MultipartOptimizer::createSuperMeshes(
 
 			// Bake the streaming mesh node by applying the transformation to the vertices
 			// Note that the bounds have already been transformed by calling transformBounds earlier
-			auto parentId = sNode.getParent();
-			if (transformMap.contains(parentId)) {
-				auto transform = transformMap.at(parentId);
-				sNode.bakeLoadedMeshes(transform);
-			}
-			else {
-				repoWarning << "createSuperMeshes; no transform found for this mesh node. Mesh will not be baked";
-			}
+			auto transform = transformMap.at(sNode.getParent());
+			sNode.bakeLoadedMeshes(transform.matrix);
 
 			if (currentSupermesh.vertices.size() + sNode.getNumLoadedVertices() <= REPO_MP_MAX_VERTEX_COUNT)
 			{
@@ -573,12 +541,12 @@ void repo::manipulator::modeloptimizer::MultipartOptimizer::createSuperMeshes(
 			else if (sNode.getNumLoadedVertices() > REPO_MP_MAX_VERTEX_COUNT)
 			{
 				// The node is too big to fit into any supermesh, so it must be split
-				splitMesh(sNode, exporter, matPropMap, texId);
+				splitMesh(sNode, exporter, matPropMap, texId, namedGrouping);
 			}
 			else
 			{
 				// The node is small enough to fit within one supermesh, just not this one
-				createSuperMesh(exporter, currentSupermesh);
+				createSuperMesh(currentSupermesh, namedGrouping);
 				currentSupermesh = mapped_mesh_t();
 				appendMesh(sNode, matPropMap, currentSupermesh, texId);
 			}
@@ -589,17 +557,17 @@ void repo::manipulator::modeloptimizer::MultipartOptimizer::createSuperMeshes(
 
 		// Add the last supermesh to be built
 		if (currentSupermesh.vertices.size()) {
-			createSuperMesh(exporter, currentSupermesh);
+			createSuperMesh(currentSupermesh, namedGrouping);
 		}
 	}
 }
 
 void MultipartOptimizer::createSuperMesh(
-	repo::manipulator::modelconvertor::AbstractModelExport *exporter,
-	const mapped_mesh_t& mappedMesh)
+	const mapped_mesh_t& mappedMesh, const std::string& tag)
 {
 	// Create supermesh node
 	auto supermeshNode = createSupermeshNode(mappedMesh);
+	supermeshNode->setGrouping(tag);
 
 	exporter->addSupermesh(supermeshNode.get());
 }
@@ -674,12 +642,12 @@ void MultipartOptimizer::appendMesh(
 		else
 		{
 			//This shouldn't happen, if it does, then it means that mesh nodes with and without uvs have been grouped together
-			repoError << "Unexpected mismatch occured! Meshes with and without UVs grouped together!";
+			throw repo::lib::RepoException("Inconsistent UV channel count when appending mesh to supermesh. This likely means that meshes with and without UVs have been grouped together, which is not supported.");
 		}
 	}
 	else
 	{
-		repoError << "Failed merging meshes: Vertices or faces cannot be null!";
+		throw repo::lib::RepoException("Failed merging meshes: Vertices or faces cannot be null!");
 	}
 }
 
@@ -881,7 +849,8 @@ void MultipartOptimizer::splitMesh(
 	repo::core::model::StreamingMeshNode &node,
 	repo::manipulator::modelconvertor::AbstractModelExport *exporter,
 	const MaterialPropMap &matPropMap,
-	const repo::lib::RepoUUID &texId
+	const repo::lib::RepoUUID &texId,
+	const std::string& namedGrouping
 )
 {
 	// The purpose of this method is to split large MeshNodes into smaller ones.
@@ -1028,13 +997,11 @@ void MultipartOptimizer::splitMesh(
 
 		mapped.meshMapping.push_back(mapping);
 
-		createSuperMesh(exporter, mapped);
+		createSuperMesh(mapped, namedGrouping);
 	}
 
 	repoInfo << "Split mesh with " << node.getNumLoadedVertices() << " vertices into " << branchNodes.size() << " submeshes in " << CHRONO_DURATION(start) << " ms";
 }
-
-
 
 std::unique_ptr<repo::core::model::SupermeshNode> MultipartOptimizer::createSupermeshNode(
 	const mapped_mesh_t &mapped
@@ -1065,8 +1032,6 @@ std::unique_ptr<repo::core::model::SupermeshNode> MultipartOptimizer::createSupe
 		"",
 		meshMapping);
 }
-
-
 
 // Builds a Bvh of the bounds of the MeshNodes. Each MeshNode in the array is
 // the primitive.
@@ -1138,7 +1103,7 @@ std::vector<size_t> MultipartOptimizer::getVertexCounts(
 
 			if (primitiveIndex < 0 || primitiveIndex >= binIndexes.size())
 			{
-				repoError << "Bvh primitive index out of range. This means something has gone wrong with the BVH construction.";
+				throw repo::lib::RepoException("Primitive index out of bounds when calculating vertex counts for BVH nodes. This likely means there is a mismatch between the primitives in the BVH and the input meshes.");
 			}
 
 			auto& node = meshes[binIndexes[primitiveIndex]];

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
@@ -396,7 +396,8 @@ void MultipartOptimizer::clusterAndSupermesh(
 	auto cursor = handler->findCursorByCriteria(database, sceneCollection, job.filter, projection);
 
 	// Currently we support two levels of grouping when supermeshing, the
-	// MeshNode branch group, and the group tag of the Mesh itself.
+	// MeshNode branch group, and the group tag of the Mesh itself (the
+	// resource groupings from importers such as Synchro).
 
 	struct group {
 		std::string mesh;

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
@@ -49,11 +49,12 @@ static const size_t REPO_MODEL_LOW_CLUSTERING_RATIO = 0.2f;
 
 MultipartOptimizer::MultipartOptimizer(
 	repo::core::handler::AbstractDatabaseHandler* handler,
-	repo::manipulator::modelconvertor::AbstractModelExport* exporter
+	repo::manipulator::modelconvertor::AbstractModelExport* exporter,
+	bool splitByFloor
 ):
 	handler(handler),
 	exporter(exporter),
-	splitByFloor(false)
+	splitByFloor(splitByFloor)
 {
 }
 
@@ -74,15 +75,15 @@ void MultipartOptimizer::processScene(
 	repoInfo << "Creating Processing Jobs";
 	std::vector<ProcessingJob> jobs;
 
-	jobs.push_back(createUntexturedJob(revId, 2, false, false));
-	jobs.push_back(createUntexturedJob(revId, 2, false, true));
-	jobs.push_back(createUntexturedJob(revId, 2, true, false));
-	jobs.push_back(createUntexturedJob(revId, 2, true, true));
+	jobs.push_back(createUntexturedJob(revId, 2, false, false)); // Transparent, primitive 2, No normals
+	jobs.push_back(createUntexturedJob(revId, 2, false, true)); // Transparent, primitive 2, With normals
+	jobs.push_back(createUntexturedJob(revId, 2, true, false)); // Opaque, primitive 2, No normals
+	jobs.push_back(createUntexturedJob(revId, 2, true, true)); // Opaque, primitive 2, With normals
 	
-	jobs.push_back(createUntexturedJob(revId, 3, false, false));
-	jobs.push_back(createUntexturedJob(revId, 3, false, true));
-	jobs.push_back(createUntexturedJob(revId, 3, true, false));
-	jobs.push_back(createUntexturedJob(revId, 3, true, true));
+	jobs.push_back(createUntexturedJob(revId, 3, false, false)); // Transparent, primitive 3, No normals
+	jobs.push_back(createUntexturedJob(revId, 3, false, true)); // Transparent, primitive 3, With normals
+	jobs.push_back(createUntexturedJob(revId, 3, true, false)); // Opaque, primitive 3, No normals
+	jobs.push_back(createUntexturedJob(revId, 3, true, true)); // Opaque, primitive 3, With normals
 	
 	// Get Texture IDs
 	repoInfo << "Getting all texture Ids";
@@ -98,7 +99,7 @@ void MultipartOptimizer::processScene(
 		jobs.push_back(createTexturedJob(revId, 3, false, texId));
 		jobs.push_back(createTexturedJob(revId, 3, true, texId));
 	}
-	
+
 	// Process jobs
 	repoInfo << "Processing Jobs";
 

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.cpp
@@ -172,6 +172,15 @@ MultipartOptimizer::TransformMap MultipartOptimizer::getAllTransforms(
 	return transformMap;
 }
 
+MultipartOptimizer::BranchGroup* MultipartOptimizer::createBranchGroup(const std::string& name)
+{
+	auto group = std::make_unique<BranchGroup>();
+	group->name = name;
+	auto ptr = group.get();
+	branchGroups.push_back(std::move(group));
+	return ptr;
+}
+
 void MultipartOptimizer::applyBranchGroups(
 	TransformMap& transforms, 
 	const std::string& database,
@@ -205,8 +214,7 @@ void MultipartOptimizer::applyBranchGroups(
 
 		auto& groupPtr = branchGroupsByTag[value];
 		if (!groupPtr) {
-			groupPtr = new BranchGroup();
-			groupPtr->name = value;
+			groupPtr = createBranchGroup(value);
 		}
 
 		for (auto& parent : metadataNode.getParentIDs()) {

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
@@ -39,21 +39,25 @@ namespace repo {
 		namespace modeloptimizer {
 			class MultipartOptimizer
 			{
-				
 				typedef float Scalar;
 				typedef bvh::Bvh<Scalar> Bvh;
 				typedef bvh::Vector3<Scalar> BvhVector3;
 
+				repo::core::handler::AbstractDatabaseHandler* handler;
+				repo::manipulator::modelconvertor::AbstractModelExport* exporter;
+
 			public:
 				
-				bool processScene(
-					std::string database,
-					std::string collection,
-					repo::lib::RepoUUID revId,
-					repo::core::handler::AbstractDatabaseHandler *handler,
-					repo::manipulator::modelconvertor::AbstractModelExport *exporter
+				MultipartOptimizer(
+					repo::core::handler::AbstractDatabaseHandler* handler,
+					repo::manipulator::modelconvertor::AbstractModelExport* exporter
 				);
 
+				void processScene(
+					std::string database,
+					std::string collection,
+					repo::lib::RepoUUID revId
+				);
 
 			private:
 
@@ -76,14 +80,27 @@ namespace repo {
 					bool isTexturedJob() const {
 						return !texId.isDefaultValue();
 					}
-				};							
-				
+				};
+
+				struct BranchGroup {
+					std::string name; // The tag that gets associated with any supermeshes
+				};
+
+				/*
+				* Contains the baked transformation information, i.e. the final conditions
+				* of the Transformation just above a MeshNode.
+				*/
+				struct TransformInfo {
+					repo::lib::RepoMatrix matrix;
+					BranchGroup* branch = nullptr;
+				};
 
 				typedef std::unordered_map <repo::lib::RepoUUID, std::shared_ptr<repo::core::model::MaterialNode>, repo::lib::RepoUUIDHasher> MaterialPropMap;
-				typedef std::unordered_map<repo::lib::RepoUUID, repo::lib::RepoMatrix, repo::lib::RepoUUIDHasher> TransformMap;
+				typedef std::unordered_map<repo::lib::RepoUUID, TransformInfo, repo::lib::RepoUUIDHasher> TransformMap;
 
-				std::unordered_map<repo::lib::RepoUUID, repo::lib::RepoMatrix, repo::lib::RepoUUIDHasher> getAllTransforms(
-					repo::core::handler::AbstractDatabaseHandler *handler,
+				std::vector<BranchGroup> branchGroups;
+
+				TransformMap getAllTransforms(
 					const std::string &database,
 					const std::string &collection,
 					const repo::lib::RepoUUID &revId
@@ -92,44 +109,40 @@ namespace repo {
 				void traverseTransformTree(
 					const repo::core::model::RepoBSON &root,
 					const std::unordered_map<repo::lib::RepoUUID, std::vector<repo::core::model::RepoBSON>, repo::lib::RepoUUIDHasher> &childNodeMap,
-					std::unordered_map<repo::lib::RepoUUID,	repo::lib::RepoMatrix, repo::lib::RepoUUIDHasher> &transforms);
+					TransformMap &transforms);
+
+				/*
+				* Uses metadata queries to find branching groups, and apply them to the
+				* transform map. Currently the metadata queries are static.
+				*/
+				void applyBranchGroups(
+					TransformMap& transforms, 
+					const std::string& database,
+					const std::string& collection, 
+					const repo::lib::RepoUUID &revId);
 
 				MaterialPropMap getAllMaterials(
-					repo::core::handler::AbstractDatabaseHandler *handler,
 					const std::string &database,
 					const std::string &collection,
 					const repo::lib::RepoUUID &revId
 				);
 
-				std::set<std::string> getAllGroupings(
-					repo::core::handler::AbstractDatabaseHandler* handler,
-					const std::string& database,
-					const std::string& collection,
-					const repo::lib::RepoUUID& revId
-				);
-
 				std::vector < repo::lib::RepoUUID> getAllTextureIds(
-					repo::core::handler::AbstractDatabaseHandler *handler,
 					const std::string &database,
 					const std::string &collection,
-					const repo::lib::RepoUUID &revId,
-					const std::string& grouping
+					const repo::lib::RepoUUID &revId
 				);
 
 				ProcessingJob createUntexturedJob(
-					const std::string &description,
 					const repo::lib::RepoUUID &revId,
 					const int primitive,
-					const std::string &grouping,
 					const bool isOpaque,
 					const bool hasNormals
 				);
 
 				ProcessingJob createTexturedJob(
-					const std::string &description,
 					const repo::lib::RepoUUID &revId,
 					const int primitive,
-					const std::string &grouping,
 					const bool hasNormals,
 					const repo::lib::RepoUUID &texId
 				);
@@ -137,8 +150,6 @@ namespace repo {
 				void clusterAndSupermesh(
 					const std::string &database,
 					const std::string &collection,
-					repo::core::handler::AbstractDatabaseHandler *handler,
-					repo::manipulator::modelconvertor::AbstractModelExport *exporter,
 					const TransformMap& transformMap,
 					const MaterialPropMap& matPropMap,
 					const ProcessingJob &job
@@ -147,18 +158,17 @@ namespace repo {
 				void createSuperMeshes(
 					const std::string &database,
 					const std::string &collection,
-					repo::core::handler::AbstractDatabaseHandler *handler,
-					repo::manipulator::modelconvertor::AbstractModelExport *exporter,
 					const TransformMap& transformMap,
 					const MaterialPropMap& matPropMap,
 					std::vector<repo::core::model::StreamingMeshNode>& meshNodes,
 					const std::vector<std::vector<int>>& clusters,
-					const repo::lib::RepoUUID &texId
+					const repo::lib::RepoUUID &texId,
+					const std::string& namedGrouping
 				);
 
 				void createSuperMesh(
-					repo::manipulator::modelconvertor::AbstractModelExport *exporter,
-					const mapped_mesh_t& mappedMesh
+					const mapped_mesh_t& mappedMesh,
+					const std::string& tag
 				);
 
 				void appendMesh(					
@@ -196,7 +206,8 @@ namespace repo {
 					repo::core::model::StreamingMeshNode &node,
 					repo::manipulator::modelconvertor::AbstractModelExport *exporter,
 					const MaterialPropMap &matPropMap,
-					const repo::lib::RepoUUID &texId
+					const repo::lib::RepoUUID &texId,
+					const std::string& namedGrouping
 				);
 
 				/*

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
@@ -47,7 +47,6 @@ namespace repo {
 				repo::manipulator::modelconvertor::AbstractModelExport* exporter;
 
 			public:
-				
 				MultipartOptimizer(
 					repo::core::handler::AbstractDatabaseHandler* handler,
 					repo::manipulator::modelconvertor::AbstractModelExport* exporter
@@ -58,6 +57,8 @@ namespace repo {
 					std::string collection,
 					repo::lib::RepoUUID revId
 				);
+
+				bool splitByFloor;
 
 			private:
 

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
@@ -54,7 +54,8 @@ namespace repo {
 			public:
 				MultipartOptimizer(
 					repo::core::handler::AbstractDatabaseHandler* handler,
-					repo::manipulator::modelconvertor::AbstractModelExport* exporter
+					repo::manipulator::modelconvertor::AbstractModelExport* exporter,
+					bool splitByFloor = false
 				);
 
 				void processScene(
@@ -63,9 +64,8 @@ namespace repo {
 					repo::lib::RepoUUID revId
 				);
 
-				bool splitByFloor;
-
 			private:
+				bool splitByFloor;
 
 				/**
 				* Represents a batched set of geometry.

--- a/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
+++ b/bouncer/src/repo/manipulator/modeloptimizer/repo_optimizer_multipart.h
@@ -104,7 +104,14 @@ namespace repo {
 				typedef std::unordered_map <repo::lib::RepoUUID, std::shared_ptr<repo::core::model::MaterialNode>, repo::lib::RepoUUIDHasher> MaterialPropMap;
 				typedef std::unordered_map<repo::lib::RepoUUID, TransformInfo, repo::lib::RepoUUIDHasher> TransformMap;
 
-				std::vector<BranchGroup> branchGroups;
+				std::vector<std::unique_ptr<BranchGroup>> branchGroups;
+
+				/*
+				* Creates a new branch group with the given name. This will be cleaned up
+				* automatically when the optimizer is destroyed. This will not check for
+				* duplicates.
+				*/
+				BranchGroup* createBranchGroup(const std::string& name);
 
 				TransformMap getAllTransforms(
 					const std::string &database,

--- a/bouncer/src/repo/manipulator/modelutility/clashdetection/clash_pipelines.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/clashdetection/clash_pipelines.cpp
@@ -25,6 +25,7 @@
 #include <repo/lib/datastructure/repo_matrix.h>
 #include <repo/lib/datastructure/repo_bounds.h>
 #include <repo/lib/datastructure/repo_triangle.h>
+#include <repo/lib/repo_hash_combine.h>
 #include <repo/core/handler/repo_database_handler_abstract.h>
 #include <repo/core/handler/database/repo_query.h>
 #include <repo/core/model/repo_model_global.h>
@@ -44,8 +45,6 @@ using namespace repo::manipulator::modelutility;
 using namespace repo::manipulator::modelutility::clash;
 
 using ContainerGroups = std::unordered_map<repo::lib::Container*, std::vector<repo::lib::RepoUUID>>;
-
-#define HASH_GOLDEN_RATIO 0x9e3779b9
 
 Graph::Graph(std::vector<Node> nodes)
 	: meshes(std::move(nodes))
@@ -306,11 +305,10 @@ void Pipeline::createClashReport(const OrderedPair& objects, const CompositeClas
 	// however as these is what the fingerprint is intended to discriminate between.
 
 	size_t hash = 0;
-	std::hash<double> hasher;
 	for (auto& p : result.positions) {
-		hash ^= hasher(p.x) + HASH_GOLDEN_RATIO + (hash << 6) + (hash >> 2);
-		hash ^= hasher(p.y) + HASH_GOLDEN_RATIO + (hash << 6) + (hash >> 2);
-		hash ^= hasher(p.z) + HASH_GOLDEN_RATIO + (hash << 6) + (hash >> 2);
+		hash_combine(hash, p.x);
+		hash_combine(hash, p.y);
+		hash_combine(hash, p.z);
 	}
 	result.fingerprint = hash;
 }

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
@@ -31,13 +31,14 @@ using namespace repo::manipulator::modelutility;
 
 
 uint8_t SceneManager::commitScene(
-	repo::core::model::RepoScene									*scene,
-	const std::string												&owner,
-	const std::string												&tag,
-	const std::string												&desc,
-	const repo::lib::RepoUUID										&revId,
-	repo::core::handler::AbstractDatabaseHandler					*handler,
-	repo::core::handler::fileservice::FileManager					*fileManager
+	repo::core::model::RepoScene* scene,
+	const std::string& owner,
+	const std::string& tag,
+	const std::string& desc,
+	const repo::lib::RepoUUID& revId,
+	repo::core::handler::AbstractDatabaseHandler* handler,
+	repo::core::handler::fileservice::FileManager* fileManager,
+	const repo::manipulator::modelutility::WebBufferConfig& config
 ) {
 	uint8_t errCode = REPOERR_UPLOAD_FAILED;
 	std::string msg;
@@ -63,7 +64,7 @@ uint8_t SceneManager::commitScene(
 			{
 				repoInfo << "Generating Repo Bundles...";
 				scene->updateRevisionStatus(handler, repo::core::model::ModelRevisionNode::UploadStatus::GEN_WEB_STASH);
-				if (success = generateWebViewBuffers(scene, repo::manipulator::modelconvertor::ExportType::REPO, handler))
+				if (success = generateWebViewBuffers(scene, repo::manipulator::modelconvertor::ExportType::REPO, handler, config))
 					repoInfo << "Repo Bundles for Stash stored into the database";
 				else
 					repoError << "failed to commit Repo Bundles";
@@ -201,9 +202,11 @@ void SceneManager::fetchScene(
 }
 
 bool SceneManager::generateWebViewBuffers(
-	repo::core::model::RepoScene									*scene,
-	const repo::manipulator::modelconvertor::ExportType				&exType,
-	repo::core::handler::AbstractDatabaseHandler					*handler)
+	repo::core::model::RepoScene *scene,
+	const repo::manipulator::modelconvertor::ExportType &exType,
+	repo::core::handler::AbstractDatabaseHandler *handler,
+	const repo::manipulator::modelutility::WebBufferConfig& config
+)
 {
 	bool validScene =
 		scene
@@ -252,6 +255,7 @@ bool SceneManager::generateWebViewBuffers(
 		}
 
 		repo::manipulator::modeloptimizer::MultipartOptimizer mpOpt(handler, exporter.get());
+		mpOpt.splitByFloor = config.splitByFloor;
 		mpOpt.processScene(
 			scene->getDatabaseName(),
 			scene->getProjectName(),

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
@@ -251,13 +251,11 @@ bool SceneManager::generateWebViewBuffers(
 			return false;
 		}
 
-		repo::manipulator::modeloptimizer::MultipartOptimizer mpOpt;
-		return mpOpt.processScene(
+		repo::manipulator::modeloptimizer::MultipartOptimizer mpOpt(handler, exporter.get());
+		mpOpt.processScene(
 			scene->getDatabaseName(),
 			scene->getProjectName(),
-			scene->getRevisionID(),
-			handler,
-			exporter.get() 
+			scene->getRevisionID()
 		);
 	}
 	else

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
@@ -257,6 +257,8 @@ bool SceneManager::generateWebViewBuffers(
 			scene->getProjectName(),
 			scene->getRevisionID()
 		);
+
+		return true;
 	}
 	else
 	{

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.cpp
@@ -254,8 +254,7 @@ bool SceneManager::generateWebViewBuffers(
 			return false;
 		}
 
-		repo::manipulator::modeloptimizer::MultipartOptimizer mpOpt(handler, exporter.get());
-		mpOpt.splitByFloor = config.splitByFloor;
+		repo::manipulator::modeloptimizer::MultipartOptimizer mpOpt(handler, exporter.get(), config.splitByFloor);
 		mpOpt.processScene(
 			scene->getDatabaseName(),
 			scene->getProjectName(),

--- a/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.h
+++ b/bouncer/src/repo/manipulator/modelutility/repo_scene_manager.h
@@ -14,11 +14,13 @@
 *  You should have received a copy of the GNU Affero General Public License
 *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #pragma once
-#include "../../core/model/collection/repo_scene.h"
-#include "../../core/handler/repo_database_handler_abstract.h"
-#include "../../core/handler/fileservice/repo_file_manager.h"
-#include "../modelconvertor/export/repo_model_export_abstract.h"
+#include "repo/core/model/collection/repo_scene.h"
+#include "repo/core/handler/repo_database_handler_abstract.h"
+#include "repo/core/handler/fileservice/repo_file_manager.h"
+#include "repo/manipulator/modelconvertor/export/repo_model_export_abstract.h"
+#include "repo_web_buffer_config.h"
 
 namespace repo {
 	namespace manipulator {
@@ -36,7 +38,8 @@ namespace repo {
 					const std::string												&desc,
 					const repo::lib::RepoUUID										&revId,
 					repo::core::handler::AbstractDatabaseHandler					*handler,
-					repo::core::handler::fileservice::FileManager					*fileManager
+					repo::core::handler::fileservice::FileManager					*fileManager,
+					const repo::manipulator::modelutility::WebBufferConfig& config
 				);
 
 				/**
@@ -114,9 +117,11 @@ namespace repo {
 				* @return returns repo_web_buffers upon success
 				*/
 				bool generateWebViewBuffers(
-					repo::core::model::RepoScene									*scene,
-					const repo::manipulator::modelconvertor::ExportType				&exType,
-					repo::core::handler::AbstractDatabaseHandler					*handler = nullptr);
+					repo::core::model::RepoScene								*scene,
+					const repo::manipulator::modelconvertor::ExportType			&exType,
+					repo::core::handler::AbstractDatabaseHandler				*handler,
+					const repo::manipulator::modelutility::WebBufferConfig		&config
+				);
 
 				/**
 				* Remove stash graph entry for the given scene
@@ -125,19 +130,7 @@ namespace repo {
 				* @param handler hander to the database
 				* @return returns true upon success
 				*/
-				bool removeStashGraph(
-					repo::core::model::RepoScene *scene);
-
-			private:
-				/**
-				* Generate a set of Repo Bundles in the form of web buffers for
-				* the given scene. The stash must have beeen generated already.
-				* This method requires project to have been built with
-				* REPO_ASSETGENERATOR_SUPPORT ON. If not, this method will report
-				* an error and return an empty buffers object.
-				*/
-				repo::lib::repo_web_buffers_t generateRepoBundleBuffer(
-					repo::core::model::RepoScene* scene);
+				bool removeStashGraph(repo::core::model::RepoScene *scene);
 			};
 		}
 	}

--- a/bouncer/src/repo/manipulator/modelutility/repo_web_buffer_config.h
+++ b/bouncer/src/repo/manipulator/modelutility/repo_web_buffer_config.h
@@ -1,0 +1,39 @@
+/**
+*  Copyright (C) 2026 3D Repo Ltd
+*
+*  This program is free software: you can redistribute it and/or modify
+*  it under the terms of the GNU Affero General Public License as
+*  published by the Free Software Foundation, either version 3 of the
+*  License, or (at your option) any later version.
+*
+*  This program is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*  GNU Affero General Public License for more details.
+*
+*  You should have received a copy of the GNU Affero General Public License
+*  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+namespace repo {
+	namespace manipulator {
+		namespace modelutility {
+			struct WebBufferConfig
+			{
+				/*
+				* When true, elements will be split between web assets such that each asset
+				* corresponds to at most one value from the magic floor metadata field.
+				* This is currently supported by Rvt and Ifc formats.
+				*/
+				bool splitByFloor;
+
+				WebBufferConfig():
+					splitByFloor(false)
+				{
+				}
+			};
+		}
+	}
+}

--- a/bouncer/src/repo/manipulator/repo_manipulator.cpp
+++ b/bouncer/src/repo/manipulator/repo_manipulator.cpp
@@ -39,6 +39,7 @@
 #include "modelutility/spatialpartitioning/repo_spatial_partitioner_rdtree.h"
 #include "modelutility/repo_drawing_manager.h"
 #include "modelutility/repo_clash_detection_engine.h"
+#include "modelutility/repo_web_buffer_config.h"
 
 using namespace repo::manipulator;
 
@@ -133,7 +134,8 @@ uint8_t RepoManipulator::commitScene(
 	const std::string& owner,
 	const std::string& tag,
 	const std::string& desc,
-	const repo::lib::RepoUUID& revId)
+	const repo::lib::RepoUUID& revId,
+	const WebBufferConfig& config)
 {
 	repoLog("Manipulator: Committing model to database");
 
@@ -149,7 +151,7 @@ uint8_t RepoManipulator::commitScene(
 	}
 
 	modelutility::SceneManager sceneManager;
-	return sceneManager.commitScene(scene, projOwner, tag, desc, revId, dbHandler.get(), dbHandler->getFileManager().get());
+	return sceneManager.commitScene(scene, projOwner, tag, desc, revId, dbHandler.get(), dbHandler->getFileManager().get(), config);
 }
 
 repo::core::model::RepoScene* RepoManipulator::fetchScene(
@@ -175,11 +177,14 @@ void RepoManipulator::fetchScene(
 }
 
 bool RepoManipulator::generateAndCommitRepoBundlesBuffer(
-	repo::core::model::RepoScene* scene)
+	repo::core::model::RepoScene* scene,
+	const repo::manipulator::modelutility::WebBufferConfig& config
+)
 {
 	return generateAndCommitWebViewBuffer(
 		scene,
-		modelconvertor::ExportType::REPO
+		modelconvertor::ExportType::REPO,
+		config
 	);
 }
 
@@ -193,10 +198,12 @@ bool RepoManipulator::generateAndCommitSelectionTree(
 
 bool RepoManipulator::generateAndCommitWebViewBuffer(
 	repo::core::model::RepoScene* scene,
-	const modelconvertor::ExportType& exType)
+	const modelconvertor::ExportType& exType,
+	const repo::manipulator::modelutility::WebBufferConfig& config
+)
 {
 	modelutility::SceneManager SceneManager;
-	return SceneManager.generateWebViewBuffers(scene, exType, dbHandler.get());
+	return SceneManager.generateWebViewBuffers(scene, exType, dbHandler.get(), config);
 }
 
 std::vector<repo::core::model::RepoBSON>

--- a/bouncer/src/repo/manipulator/repo_manipulator.h
+++ b/bouncer/src/repo/manipulator/repo_manipulator.h
@@ -23,12 +23,13 @@
 #include <map>
 #include <string>
 
-#include "../core/model/bson/repo_node_reference.h"
-#include "../core/model/bson/repo_node_transformation.h"
-#include "../core/model/bson/repo_node_mesh.h"
-#include "../core/model/collection/repo_scene.h"
-#include <repo/manipulator/modelutility/repo_clash_detection_config_fwd.h>
-#include "../lib/repo_config.h"
+#include "repo/core/model/bson/repo_node_reference.h"
+#include "repo/core/model/bson/repo_node_transformation.h"
+#include "repo/core/model/bson/repo_node_mesh.h"
+#include "repo/core/model/collection/repo_scene.h"
+#include "repo/manipulator/modelutility/repo_clash_detection_config_fwd.h"
+#include "repo/manipulator/modelutility/repo_web_buffer_config.h"
+#include "repo/lib/repo_config.h"
 #include "modelconvertor/export/repo_model_export_abstract.h"
 #include "modelconvertor/import/repo_model_import_config.h"
 #include "modelutility/spatialpartitioning/repo_spatial_partitioner_abstract.h"
@@ -62,7 +63,8 @@ namespace repo {
 				const std::string                     &owner = "",
 				const std::string                     &tag = "",
 				const std::string                     &desc = "",
-				const repo::lib::RepoUUID             &revId = repo::lib::RepoUUID::createUUID());
+				const repo::lib::RepoUUID             &revId = repo::lib::RepoUUID::createUUID(),
+				const modelutility::WebBufferConfig& config = {});
 
 			/**
 			* Create a federated scene with the given scene collections
@@ -122,7 +124,9 @@ namespace repo {
 			*/
 			bool generateAndCommitWebViewBuffer(
 				repo::core::model::RepoScene          *scene,
-				const modelconvertor::ExportType   &exType);
+				const modelconvertor::ExportType   &exType,
+				const repo::manipulator::modelutility::WebBufferConfig& config
+			);
 
 			/**
 			* Generate and commit RepoBundles for the given scene
@@ -131,7 +135,9 @@ namespace repo {
 			*/
 
 			bool generateAndCommitRepoBundlesBuffer(
-				repo::core::model::RepoScene* scene);
+				repo::core::model::RepoScene* scene,
+				const repo::manipulator::modelutility::WebBufferConfig& config
+			);
 
 			/**
 			* Retrieve documents from a specified collection

--- a/bouncer/src/repo/repo_controller.cpp
+++ b/bouncer/src/repo/repo_controller.cpp
@@ -57,9 +57,10 @@ uint8_t RepoController::commitScene(
 	const std::string                   &owner,
 	const std::string                      &tag,
 	const std::string                      &desc,
-	const repo::lib::RepoUUID           &revId)
+	const repo::lib::RepoUUID           &revId,
+	const repo::manipulator::modelutility::WebBufferConfig& config)
 {
-	return impl->commitScene(token, scene, owner, tag, desc, revId);
+	return impl->commitScene(token, scene, owner, tag, desc, revId, config);
 }
 
 void RepoController::destroyToken(RepoController::RepoToken* token)
@@ -130,9 +131,10 @@ repo::core::model::RepoScene* RepoController::createFederatedScene(
 
 bool RepoController::generateAndCommitRepoBundlesBuffer(
 	const RepoController::RepoToken* token,
-	repo::core::model::RepoScene* scene)
+	repo::core::model::RepoScene* scene,
+	const repo::manipulator::modelutility::WebBufferConfig& config)
 {
-	return impl->generateAndCommitRepoBundlesBuffer(token, scene);
+	return impl->generateAndCommitRepoBundlesBuffer(token, scene, config);
 }
 
 std::shared_ptr<repo::lib::repo_partitioning_tree_t>

--- a/bouncer/src/repo/repo_controller.cpp.inl
+++ b/bouncer/src/repo/repo_controller.cpp.inl
@@ -191,7 +191,8 @@ public:
 		const std::string                   &owner = "",
 		const std::string                      &tag = "",
 		const std::string                      &desc = "",
-		const repo::lib::RepoUUID           &revId = repo::lib::RepoUUID::createUUID());
+		const repo::lib::RepoUUID           &revId = repo::lib::RepoUUID::createUUID(),
+		const repo::manipulator::modelutility::WebBufferConfig& config = {});
 
 	/*
 	*	------------- Logging --------------
@@ -237,7 +238,8 @@ public:
 	*/
 	bool generateAndCommitRepoBundlesBuffer(
 		const RepoToken* token,
-		repo::core::model::RepoScene* scene);
+		repo::core::model::RepoScene* scene,
+		const repo::manipulator::modelutility::WebBufferConfig& config);
 
 	/**
 	* Generate and commit a selection tree for the given scene

--- a/bouncer/src/repo/repo_controller.h
+++ b/bouncer/src/repo/repo_controller.h
@@ -34,8 +34,9 @@
 #include "core/model/collection/repo_scene.h"
 #include "lib/datastructure/repo_structs.h"
 #include "lib/repo_config.h"
-#include "manipulator/modelconvertor/import/repo_model_import_config.h"
-#include <repo/manipulator/modelutility/repo_clash_detection_config_fwd.h>
+#include "repo/manipulator/modelconvertor/import/repo_model_import_config.h"
+#include "repo/manipulator/modelutility/repo_clash_detection_config_fwd.h"
+#include "repo/manipulator/modelutility/repo_web_buffer_config.h"
 #include "repo_bouncer_global.h"
 #include <repo_log.h>
 
@@ -192,7 +193,8 @@ namespace repo {
 			const std::string                   &owner = "",
 			const std::string                      &tag = "",
 			const std::string                      &desc = "",
-			const repo::lib::RepoUUID           &revId = repo::lib::RepoUUID::createUUID());
+			const repo::lib::RepoUUID           &revId = repo::lib::RepoUUID::createUUID(),
+			const repo::manipulator::modelutility::WebBufferConfig& config = {});
 
 		/*
 		*	------------- Logging --------------
@@ -235,7 +237,8 @@ namespace repo {
 		*/
 		bool generateAndCommitRepoBundlesBuffer(
 			const RepoToken* token,
-			repo::core::model::RepoScene* scene);
+			repo::core::model::RepoScene* scene,
+			const repo::manipulator::modelutility::WebBufferConfig& config);
 
 		/**
 		* Generate and commit a selection tree for the given scene

--- a/bouncer/src/repo/repo_controller_internal.cpp.inl
+++ b/bouncer/src/repo/repo_controller_internal.cpp.inl
@@ -85,7 +85,8 @@ uint8_t RepoController::_RepoControllerImpl::commitScene(
 	const std::string                   &owner,
 	const std::string                      &tag,
 	const std::string                      &desc,
-	const repo::lib::RepoUUID           &revId)
+	const repo::lib::RepoUUID           &revId,
+	const repo::manipulator::modelutility::WebBufferConfig& config)
 {
 	uint8_t errCode = REPOERR_UNKNOWN_ERR;
 	if (scene)
@@ -101,7 +102,8 @@ uint8_t RepoController::_RepoControllerImpl::commitScene(
 					owner.empty() ? "ANONYMOUS USER" : owner,
 					tag,
 					desc,
-					revId);
+					revId,
+					config);
 				workerPool.push(worker);
 			}
 			else
@@ -268,13 +270,14 @@ repo::core::model::RepoScene* RepoController::_RepoControllerImpl::createFederat
 
 bool RepoController::_RepoControllerImpl::generateAndCommitRepoBundlesBuffer(
 	const RepoController::RepoToken* token,
-	repo::core::model::RepoScene* scene)
+	repo::core::model::RepoScene* scene,
+	const repo::manipulator::modelutility::WebBufferConfig& config)
 {
 	bool success;
 	if (success = token && scene)
 	{
 		manipulator::RepoManipulator* worker = workerPool.pop();
-		success = worker->generateAndCommitRepoBundlesBuffer(scene);
+		success = worker->generateAndCommitRepoBundlesBuffer(scene, config);
 		workerPool.push(worker);
 	}
 	else

--- a/client/src/functions.cpp
+++ b/client/src/functions.cpp
@@ -21,6 +21,7 @@
 #include <repo/core/model/bson/repo_bson.h>
 #include <repo/core/model/bson/repo_bson_factory.h>
 #include <repo/manipulator/modelutility/repo_clash_detection_config.h>
+#include <repo/manipulator/modelutility/repo_web_buffer_config.h>
 
 #include <sstream>
 #include <fstream>
@@ -80,6 +81,16 @@ int32_t knownValid(const std::string& cmd)
 	if (cmd == cmdClash)
 		return 1;
 	return -1;
+}
+
+void replaceRepoModelPath(std::string& input) {
+	const char* env = std::getenv("REPO_MODEL_PATH");
+	if (env) {
+		size_t pos = input.find("$REPO_MODEL_PATH"); // Our conventions are to always use unix conventions
+		if (pos != std::string::npos) {
+			input.replace(pos, std::string("$REPO_MODEL_PATH").length(), env);
+		}
+	}
 }
 
 int32_t performOperation(
@@ -276,8 +287,10 @@ bool _generateStash(
 	if (scene) {
 		if (type == "repo")
 		{
+			repo::manipulator::modelutility::WebBufferConfig config;
+			config.splitByFloor = true;
 			controller->updateRevisionStatus(scene, repo::core::model::ModelRevisionNode::UploadStatus::GEN_WEB_STASH);
-			success = controller->generateAndCommitRepoBundlesBuffer(token, scene);
+			success = controller->generateAndCommitRepoBundlesBuffer(token, scene, config);
 		}
 		else if (type == "tree")
 		{
@@ -412,6 +425,7 @@ int32_t importFileAndCommit(
 			config.importAnimations = jsonTree.get<bool>("importAnimations", config.importAnimations);
 			config.viewName = jsonTree.get<std::string>("view", config.viewName);
 			config.viewStyle = jsonTree.get<std::string>("style", "");
+			config.splitByFloor = jsonTree.get<bool>("splitByFloor", config.splitByFloor);
 			auto revIdStr = jsonTree.get<std::string>("revId", "");
 			if (!revIdStr.empty()) {
 				config.revisionId = repo::lib::RepoUUID(revIdStr);
@@ -440,6 +454,8 @@ int32_t importFileAndCommit(
 		}
 	}
 
+	replaceRepoModelPath(fileLoc);
+
 	boost::filesystem::path filePath(fileLoc);
 	std::string fileExt = filePath.extension().string();
 	std::transform(fileExt.begin(), fileExt.end(), fileExt.begin(), ::toupper);
@@ -455,7 +471,10 @@ int32_t importFileAndCommit(
 	{
 		repoLog("Trying to commit this scene to database as " + config.getDatabaseName() + "." + config.getProjectName());
 
-		err = controller->commitScene(token, graph, owner, tag, desc, config.revisionId);
+		repo::manipulator::modelutility::WebBufferConfig webBufferConfig;
+		webBufferConfig.splitByFloor = config.splitByFloor;
+
+		err = controller->commitScene(token, graph, owner, tag, desc, config.revisionId, webBufferConfig);
 
 		if (err == REPOERR_OK)
 		{

--- a/ifcUtils/repo_ifc_serialiser.cpp
+++ b/ifcUtils/repo_ifc_serialiser.cpp
@@ -1576,7 +1576,9 @@ void IfcSerialiser::collectSpecialAttributes(const IfcSchema::IfcObjectDefinitio
 	}
 
 	if (auto storey = dynamic_cast<const IfcSchema::IfcBuildingStorey*>(object)) {
-		location(STOREY_LABEL) = storey->Name().get_value_or("(" + object->declaration().name() + ")");
+		auto storeyName = storey->Name().get_value_or("(" + object->declaration().name() + ")");
+		location(STOREY_LABEL) = storeyName;
+		metadata(REPO_METADATA_GROUPING_FLOOR) = storeyName; // For IfcBuildingStorey, add the magic metadata entry for floor splitting as well
 	}
 }
 

--- a/test/src/system/st_3drepobouncerClient.cpp
+++ b/test/src/system/st_3drepobouncerClient.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <stdlib.h>
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <repo/error_codes.h>
 #include <repo/repo_controller.h>
 #include "../unit/repo_test_database_info.h"
@@ -519,6 +520,37 @@ TEST(RepoClientTest, UploadTestOwner)
 	EXPECT_EQ((int)REPOERR_OK, runProcess(produceUploadFileArgs(getDataPath(importNoOwner2))));
 	EXPECT_TRUE(projectExists("testDB", importNoOwnerPro2));
 	EXPECT_TRUE(projectSettingsCheck("testDB", importNoOwnerPro2, "ANONYMOUS USER", "thisTag", "MyUpload"));
+}
+
+TEST(RepoClientTest, UploadSplitByFloors)
+{
+	auto handler = getHandler();
+
+	// Tests whether the split-by-floor option works correctly.
+	EXPECT_EQ((int)REPOERR_OK, runProcess(produceUploadFileArgs(getDataPath("importFloorsSplit.json"))));
+	EXPECT_EQ((int)REPOERR_OK, runProcess(produceUploadFileArgs(getDataPath("importFloorsNoSplit.json"))));
+
+	{
+		std::set<std::string> groups;
+		auto assets = handler->getAllFromCollectionTailable("testDB", "floors_split.stash.repobundles", 0, 1, {}, "timestamp");
+		EXPECT_EQ(assets.size(), 1);
+		for (auto& sm : assets[0].getObjectArray("metadata")) {
+			if (sm.hasField("groups")) {
+				for (auto& group : sm.getStringArray("groups")) {
+					groups.insert(group);	
+				}
+			}
+		}
+		EXPECT_THAT(groups, UnorderedElementsAre("Level 0", "Level 1", "Level 2"));
+	}
+
+	{
+		auto assets = handler->getAllFromCollectionTailable("testDB", "floors_no_split.stash.repobundles", 0, 1, {}, "timestamp");
+		EXPECT_EQ(assets.size(), 1);
+		for (auto& sm : assets[0].getObjectArray("metadata")) {
+			EXPECT_THAT(sm.hasField("groups"), IsFalse());
+		}
+	}
 }
 
 TEST(RepoClientTest, CreateFedTest)

--- a/test/src/unit/repo/core/handler/ut_repo_database_handler_mongo.cpp
+++ b/test/src/unit/repo/core/handler/ut_repo_database_handler_mongo.cpp
@@ -680,6 +680,37 @@ TEST(MongoDatabaseHandlerTest, FindOneByCriteria)
 	}
 }
 
+TEST(MongoDatabaseHandlerTest, MetadataQueries)
+{
+	// Tests that the ArrayContains query can be used for its intended purpose
+	// of working with metadata.
+
+	auto handler = getHandler();
+	auto db = REPO_GTEST_DBNAME4;
+	auto col = "rvtFloors.scene";
+
+	using namespace repo::core::handler::database;
+
+	{
+		auto results = handler->findAllByCriteria(db, col, 
+			query::ArrayContains("metadata", query::Eq("key", "Asite 3DRepo::Floor")));
+
+		std::vector<repo::lib::RepoUUID> expectedIds = {
+			repo::lib::RepoUUID("3F8465C1-2687-47A5-A1F6-6E9456222B4F"),
+			repo::lib::RepoUUID("69D49F91-4D7A-4C5C-8F83-460A743000F1"),
+			repo::lib::RepoUUID("0590E806-42A4-4AB7-A68A-0AEB4C91EE7A"),
+			repo::lib::RepoUUID("7DB87C88-6DBF-4BAD-952D-FC1C6F69943A")
+		};
+
+		std::vector<repo::lib::RepoUUID> actualIds;
+		for (auto& r : results) {
+			actualIds.push_back(r.getUUIDField(REPO_LABEL_ID));
+		}
+
+		EXPECT_THAT(actualIds, UnorderedElementsAreArray(expectedIds));
+	}
+}
+
 TEST(MongoDatabaseHandlerTest, FindOneByUniqueID)
 {
 	auto handler = getHandler();

--- a/test/src/unit/repo/core/model/bson/ut_repo_bson_assets.cpp
+++ b/test/src/unit/repo/core/model/bson/ut_repo_bson_assets.cpp
@@ -52,6 +52,9 @@ TEST(RepoAssetsTest, Serialise)
 		md.primitive = 2 + rand() % 2;
 		md.numSubmeshes = rand();
 		md.numComponents = rand();
+		md.addGrouping(repo::lib::RepoUUID::createUUID().toString());
+		md.addGrouping(repo::lib::RepoUUID::createUUID().toString());
+		md.addGrouping({});
 		metadata.push_back(md);
 	}
 
@@ -85,6 +88,7 @@ TEST(RepoAssetsTest, Serialise)
 		m.numVertices = o.getIntField(REPO_ASSETS_LABEL_NUMVERTICES);
 		m.numSubmeshes = o.getIntField(REPO_ASSETS_LABEL_NUMSUBMESHES);
 		m.numComponents = o.getIntField(REPO_ASSETS_LABEL_NUMCOMPONENTS);
+		m.groups = o.getStringArray(REPO_ASSETS_LABEL_GROUPS);
 		actual.push_back(m);
 	}
 	EXPECT_THAT(actual, Eq(metadata));

--- a/test/src/unit/repo/core/model/bson/ut_repo_bson_assets.cpp
+++ b/test/src/unit/repo/core/model/bson/ut_repo_bson_assets.cpp
@@ -30,17 +30,6 @@
 using namespace repo::core::model;
 using namespace testing;
 
-namespace repo {
-	namespace core {
-		namespace model {
-			static bool operator== (const RepoSupermeshMetadata& a, const RepoSupermeshMetadata& b)
-			{
-				return memcmp(&a, &b, sizeof(a)) == 0;
-			}
-		}
-	}
-}
-
 TEST(RepoAssetsTest, Serialise)
 {
 	auto rid = repo::lib::RepoUUID::createUUID();

--- a/test/src/unit/repo/core/model/bson/ut_repo_node_streaming_mesh.cpp
+++ b/test/src/unit/repo/core/model/bson/ut_repo_node_streaming_mesh.cpp
@@ -27,6 +27,13 @@ using namespace repo::core::model;
 using namespace testing;
 using namespace repo::test::utils::mesh;
 
+#define EXPECT_REPO_EXCEPTION(statement) \
+	try { \
+		statement; \
+		FAIL() << "Expected an exception to be thrown"; \
+	} catch (const repo::lib::RepoException& e) { \
+	}
+
 TEST(StreamingMeshNodeTest, EmptyConstructor)
 {
 	StreamingMeshNode empty;
@@ -39,13 +46,13 @@ TEST(StreamingMeshNodeTest, EmptyConstructor)
 	EXPECT_EQ(empty.getBoundingBox(), repo::lib::RepoBounds());
 
 	// Check data that should not be accessible yet
-	EXPECT_TRUE(empty.getUniqueId().isDefaultValue());
-	EXPECT_EQ(empty.getNumLoadedFaces(), 0);	
-	EXPECT_EQ(empty.getLoadedFaces().size(), 0);
-	EXPECT_EQ(empty.getNumLoadedVertices(), 0);
-	EXPECT_EQ(empty.getLoadedVertices().size(), 0);
-	EXPECT_EQ(empty.getLoadedNormals().size(), 0);
-	EXPECT_EQ(empty.getLoadedUVChannelsSeparated().size(), 0);
+	EXPECT_REPO_EXCEPTION(empty.getUniqueId());
+	EXPECT_REPO_EXCEPTION(empty.getNumLoadedFaces());
+	EXPECT_REPO_EXCEPTION(empty.getLoadedFaces());
+	EXPECT_REPO_EXCEPTION(empty.getNumLoadedVertices());
+	EXPECT_REPO_EXCEPTION(empty.getLoadedVertices());
+	EXPECT_REPO_EXCEPTION(empty.getLoadedNormals());
+	EXPECT_REPO_EXCEPTION(empty.getLoadedUVChannelsSeparated());
 }
 
 TEST(StreamingMeshNodeTest, LoadBasicStreamingMeshNode) {
@@ -64,13 +71,13 @@ TEST(StreamingMeshNodeTest, LoadBasicStreamingMeshNode) {
 			repo::lib::RepoVector3D(meshData.boundingBox[1])));
 	
 	// Check data that should not be accessible yet
-	EXPECT_TRUE(limited.getUniqueId().isDefaultValue());
-	EXPECT_EQ(limited.getNumLoadedFaces(), 0);
-	EXPECT_EQ(limited.getLoadedFaces().size(), 0);
-	EXPECT_EQ(limited.getNumLoadedVertices(), 0);
-	EXPECT_EQ(limited.getLoadedVertices().size(), 0);
-	EXPECT_EQ(limited.getLoadedNormals().size(), 0);
-	EXPECT_EQ(limited.getLoadedUVChannelsSeparated().size(), 0);
+	EXPECT_REPO_EXCEPTION(limited.getUniqueId());
+	EXPECT_REPO_EXCEPTION(limited.getNumLoadedFaces());
+	EXPECT_REPO_EXCEPTION(limited.getLoadedFaces());
+	EXPECT_REPO_EXCEPTION(limited.getNumLoadedVertices());
+	EXPECT_REPO_EXCEPTION(limited.getLoadedVertices());
+	EXPECT_REPO_EXCEPTION(limited.getLoadedNormals());
+	EXPECT_REPO_EXCEPTION(limited.getLoadedUVChannelsSeparated());
 }
 
 void TestLoadSupermeshingData(mesh_data meshData) {
@@ -81,13 +88,13 @@ void TestLoadSupermeshingData(mesh_data meshData) {
 	StreamingMeshNode node = StreamingMeshNode(bson);
 
 	// Check data that should not be accessible yet
-	EXPECT_TRUE(node.getUniqueId().isDefaultValue());
-	EXPECT_EQ(node.getNumLoadedFaces(), 0);
-	EXPECT_EQ(node.getLoadedFaces().size(), 0);
-	EXPECT_EQ(node.getNumLoadedVertices(), 0);
-	EXPECT_EQ(node.getLoadedVertices().size(), 0);
-	EXPECT_EQ(node.getLoadedNormals().size(), 0);
-	EXPECT_EQ(node.getLoadedUVChannelsSeparated().size(), 0);
+	EXPECT_REPO_EXCEPTION(node.getUniqueId());
+	EXPECT_REPO_EXCEPTION(node.getNumLoadedFaces());
+	EXPECT_REPO_EXCEPTION(node.getLoadedFaces());
+	EXPECT_REPO_EXCEPTION(node.getNumLoadedVertices());
+	EXPECT_REPO_EXCEPTION(node.getLoadedVertices());
+	EXPECT_REPO_EXCEPTION(node.getLoadedNormals());
+	EXPECT_REPO_EXCEPTION(node.getLoadedUVChannelsSeparated());
 
 	// Inflate node
 	auto data = bson.getBinariesAsBuffer();
@@ -109,13 +116,14 @@ void TestLoadSupermeshingData(mesh_data meshData) {
 
 	// Check the deflated node's data
 	// It should be back to the previous state		
-	EXPECT_TRUE(node.getUniqueId().isDefaultValue());
-	EXPECT_EQ(node.getNumLoadedFaces(), 0);
-	EXPECT_EQ(node.getLoadedFaces().size(), 0);
-	EXPECT_EQ(node.getNumLoadedVertices(), 0);
-	EXPECT_EQ(node.getLoadedVertices().size(), 0);
-	EXPECT_EQ(node.getLoadedNormals().size(), 0);
-	EXPECT_EQ(node.getLoadedUVChannelsSeparated().size(), 0);
+	// Check data that should not be accessible yet
+	EXPECT_REPO_EXCEPTION(node.getUniqueId());
+	EXPECT_REPO_EXCEPTION(node.getNumLoadedFaces());
+	EXPECT_REPO_EXCEPTION(node.getLoadedFaces());
+	EXPECT_REPO_EXCEPTION(node.getNumLoadedVertices());
+	EXPECT_REPO_EXCEPTION(node.getLoadedVertices());
+	EXPECT_REPO_EXCEPTION(node.getLoadedNormals());
+	EXPECT_REPO_EXCEPTION(node.getLoadedUVChannelsSeparated());
 }
 
 TEST(StreamingMeshNodeTest, LoadSupermeshingData) {

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -706,6 +706,50 @@ TEST_F(NwdTestSuite, MetadataParentsNWD)
 	}
 }
 
+TEST_F(NwdTestSuite, MagicMetadataNwdFloors)
+{
+	// In Nwd files, we should support the floor magic metadata when the Nwd hosts
+	// either Ifc or Rvt files.
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MagicMetadataNwdFloorsRvt", getDataPath("floors_and_levels_rvt.nwd")));
+
+		std::vector<std::string> expectedFloorValues = {
+			"<No level>",
+			"Level 0",
+			"Level 1",
+			"Level 2",
+			"Planting Level Ground"
+		};
+
+		for (auto& name : expectedFloorValues) {
+			auto nodes = scene.findNodesByMetadata(REPO_METADATA_GROUPING_FLOOR, name);
+			EXPECT_THAT(nodes.size(), Eq(1)) << name;
+			for (auto& node : nodes) {
+				EXPECT_THAT(boost::apply_visitor(repo::lib::StringConversionVisitor(), node.getMetadata()[REPO_METADATA_GROUPING_FLOOR]), Eq(name));
+				EXPECT_THAT(node.getParent().name(), Eq(std::string("floors_and_levels_rvt.nwd")));
+			}
+		}
+	}
+	{
+		SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport("MagicMetadataNwdFloorsIfc", getDataPath("floors_and_levels_ifc.nwd")));
+
+		std::vector<std::string> expectedFloorValues = {
+			"Level 0",
+			"Level 1",
+			"Level 2",
+		};
+
+		for (auto& name : expectedFloorValues) {
+			auto nodes = scene.findNodesByMetadata(REPO_METADATA_GROUPING_FLOOR, name);
+			EXPECT_THAT(nodes.size(), Eq(1)) << name;
+			for (auto& node : nodes) {
+				EXPECT_THAT(boost::apply_visitor(repo::lib::StringConversionVisitor(), node.getMetadata()[REPO_METADATA_GROUPING_FLOOR]), Eq(name));
+				EXPECT_THAT(node.getParent().name(), Eq(std::string("IfcBuilding")));
+			}
+		}
+	}
+}
+
 TEST(ODAModelImport, MetadataParents)
 {
 	{

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -624,6 +624,67 @@ TEST(ODAModelImport, RvtUnits)
 	}
 }
 
+TEST(ODAModelImport, MagicMetadataRvtFloors)
+{
+	// When importing a Revit file, the appropriate tree entries should have the
+	// special 3DRepo Floor metadata assigned.
+
+	ModelImportConfig config(repo::lib::RepoUUID::createUUID(), TESTDB, "RevitFloorsAndLevels");
+	config.targetUnits = ModelUnits::MILLIMETRES;
+	config.viewName = "repo"; // Override default view to get one that shows Masses for this test
+	SceneUtils scene(ODAModelImportUtils::ModelImportManagerImport(getDataPath("rvt/floors_and_levels.rvt"), config));
+
+	// Revit has an explicit concept of levels, which are placed using elevation
+	// views. Still, the representation of levels in contstraints varies depending
+	// on the Family. The following objects are of a variety of Families and should
+	// all appear under the correct level regardless.
+
+	auto checkElementFloor = [&](std::string elementId, std::string expectedFloorValue) {
+		auto node = scene.findNodeByMetadata("Element ID", elementId);
+		auto parent = node.getParent();
+		auto metadata = parent.getMetadata();
+		EXPECT_THAT(boost::apply_visitor(repo::lib::StringConversionVisitor(), metadata[REPO_METADATA_GROUPING_FLOOR]), Eq(expectedFloorValue));
+	};
+
+	checkElementFloor("326836", "Layer Default");
+
+	checkElementFloor("323345", "Level 0");
+	checkElementFloor("323484", "Level 0");
+	checkElementFloor("323643", "Level 0");
+	checkElementFloor("321553", "Level 0");
+	checkElementFloor("322420", "Level 0");
+	checkElementFloor("322619", "Level 0");
+	checkElementFloor("319611", "Level 0");
+	checkElementFloor("320440", "Level 0");
+	checkElementFloor("322400", "Level 0");
+	checkElementFloor("315582", "Level 0");
+	checkElementFloor("315675", "Level 0");
+	checkElementFloor("315812", "Level 0");
+	checkElementFloor("319105", "Level 0");
+	checkElementFloor("321130", "Level 0");
+	checkElementFloor("317879", "Level 0");
+	checkElementFloor("318094", "Level 0");
+
+	checkElementFloor("324002", "Level 1");
+	checkElementFloor("321593", "Level 1");
+	checkElementFloor("322721", "Level 1");
+	checkElementFloor("322810", "Level 1");
+	checkElementFloor("322902", "Level 1");
+	checkElementFloor("319859", "Level 1");
+	checkElementFloor("320479", "Level 1");
+	checkElementFloor("326866", "Level 1");
+	checkElementFloor("323131", "Level 1");
+	checkElementFloor("318474", "Level 1");
+
+	checkElementFloor("321906", "Level 2");
+	checkElementFloor("322245", "Level 2");
+	checkElementFloor("319431", "Level 2");
+
+	checkElementFloor("326881", "Planting Level Ground");
+	checkElementFloor("320061", "Planting Level Ground");
+	checkElementFloor("326867", "Planting Level Ground");
+}
+
 TEST_F(NwdTestSuite, MetadataParentsNWD)
 {
 	// All metadata nodes must also have their sibling meshnodes as parents,

--- a/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_ifc.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/ut_repo_model_import_ifc.cpp
@@ -852,3 +852,18 @@ TEST(IFCModelImport, MetadataParents)
 		common::checkMetadataInheritence(scene);
 	}
 }
+
+TEST(IFCModelImport, IfcBuildingStoreyHasMagicMetadata)
+{
+	// Nodes created from IfcBuildingStorey entities should have the magic metadata
+	// for splitting by floor.
+
+	SceneUtils scene(IfcModelImportUtils::ModelImportManagerImport("IfcMetadataTests", getDataPath("floors_and_levels.ifc")));
+
+	for (auto n : scene.findNodesByMetadata("IFC Type", "IfcBuildingStorey")) {
+		auto md = n.getMetadata();
+		auto it = md.find(REPO_METADATA_GROUPING_FLOOR);
+		EXPECT_THAT(it, Not(Eq(md.end())));
+		EXPECT_THAT(it->second, Vs(n.name()));
+	}
+}

--- a/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
+++ b/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
@@ -491,8 +491,6 @@ TEST(MultipartOptimizer, TestMeshGroupings)
 	);
 }
 
-#pragma optimize("", off)
-
 namespace {
 
 	// These methods are for use exclusively by TestBranchGroupings.
@@ -645,7 +643,7 @@ TEST(MultipartOptimizer, TestBranchGroupings)
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({0, 0, 0}));
 
 	MultipartOptimizer opt(handler.get(), mockExporter.get());
-
+	opt.splitByFloor = true;
 	opt.processScene(
 		database,
 		projectName,

--- a/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
+++ b/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
@@ -18,11 +18,13 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <cstdlib>
-#include <repo/manipulator/modeloptimizer/repo_optimizer_multipart.h>
 #include <limits>
-#include <test/src/unit/repo_test_mesh_utils.h>
+#include <unordered_set>
+#include <algorithm>
+#include <repo/manipulator/modeloptimizer/repo_optimizer_multipart.h>
 #include <repo/core/model/bson/repo_bson_factory.h>
 #include <repo/manipulator/modelutility/repo_scene_builder.h>
+#include <test/src/unit/repo_test_mesh_utils.h>
 #include <test/src/unit/repo_test_database_info.h>
 #include <test/src/unit/repo_test_random_generator.h>
 
@@ -323,20 +325,16 @@ TEST(MultipartOptimizer, TestSplittingLocality)
 	// should split the vertices so that the resulting supermeshes contain only vertices belonging to
 	// one of the cluster origins and not multiples.
 
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestSplitting";
 	auto revId = repo::lib::RepoUUID::createUUID();
-
 
 	auto sceneBuilder = repo::manipulator::modelutility::RepoSceneBuilder(handler, database, projectName, revId);
 
 	auto rootNode = repo::core::model::RepoBSONFactory::makeTransformationNode({}, "rootNode", {});
 	sceneBuilder.addNode(rootNode);
 	auto rootNodeId = rootNode.getSharedID();
-
 
 	// Generate random cluster positions.
 
@@ -381,15 +379,12 @@ TEST(MultipartOptimizer, TestSplittingLocality)
 
 	// Process with mock exporter
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
-	bool result = opt.processScene(
+	auto opt = MultipartOptimizer(handler.get(), mockExporter.get());
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -624,6 +619,19 @@ namespace {
 			repo::core::model::RepoBSONFactory::makeMetaDataNode(metadata, {}, {parentId})
 		);
 	}
+
+	void removeDuplicateIds(std::vector<repo::lib::RepoUUID>& ids) {
+		std::unordered_set<repo::lib::RepoUUID, repo::lib::RepoUUIDHasher> seen;
+		ids.erase(std::remove_if(ids.begin(), ids.end(), [&seen](const repo::lib::RepoUUID& id) {
+			if (seen.find(id) != seen.end()) {
+				return true;
+			}
+			else {
+				seen.insert(id);
+				return false;
+			}
+		}), ids.end());
+	}
 }
 
 TEST(MultipartOptimizer, TestBranchGroupings)
@@ -681,6 +689,10 @@ TEST(MultipartOptimizer, TestBranchGroupings)
 	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "", {rootNode->getSharedID()}));
 	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "", {rootNode->getSharedID()}));
 
+	// The grouping logic must be robust to split meshes too
+
+	expectedGroupNull.addNode(createRandomMesh(REPO_MP_MAX_VERTEX_COUNT + nVertices, false, 3, "", {rootNode->getSharedID()}));
+
 	rootNode = nullptr; // Release rootnode or it won't be comitted.
 
 	// Meshes further down the tree, which have no grouping ancestor, should also
@@ -702,6 +714,9 @@ TEST(MultipartOptimizer, TestBranchGroupings)
 	expectedGroup1.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_1"]}));
 	expectedGroup1.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_1_1_1"]}));
 	expectedGroup1.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_1_1_2_1"]}));
+
+	expectedGroup1.addNode(createRandomMesh(REPO_MP_MAX_VERTEX_COUNT + nVertices, false, 3, "", {nodes["rootNode_1_1_2_1"]}));
+	expectedGroup1.addNode(createRandomMesh(REPO_MP_MAX_VERTEX_COUNT + nVertices, false, 3, "", {nodes["rootNode_1_1_2_2"]}));
 
 	// Branch group 3 should take precedence over branch group 2, for nodes
 	// further down.
@@ -766,7 +781,9 @@ TEST(MultipartOptimizer, TestBranchGroupings)
 			for (const auto& pair : mapping) {
 				actualIds.push_back(pair.mesh_id);
 
-				// MeshNode resource groupings must not cross supermeshes
+				// MeshNode resource groupings must not cross supermeshes. This snippet
+				// checks that the grouping of every meshNode in this supermesh is the
+				// same.
 
 				const auto& meshNodeGrouping = group.nodeIdsToGrouping.at(pair.mesh_id);
 				if (!runningMeshNodeGrouping) {
@@ -777,12 +794,19 @@ TEST(MultipartOptimizer, TestBranchGroupings)
 				}
 			}
 
-			// A single grouping may have multiple supermeshes, because there is a lot of
-			// geometry, or because there are multiple MeshNode grouping entries (even
-			// though these will not be public).
+			// A single branch grouping may have multiple supermeshes, because there is a
+			// lot of geometry, or because there are multiple MeshNode grouping entries 
+			// (even though these will not be public).
 
 			EXPECT_THAT(supermeshNode->getGrouping(), testing::Eq(group.name));
 		}
+
+		// Ultimately, between all the supermeshes, under the branch group, we should
+		// have exactly the meshNode's that should be in those groups, regardless of how
+		// they are distributed.
+
+		// Remove duplicates because split meshes will show up multiple times
+		removeDuplicateIds(actualIds);
 
 		EXPECT_THAT(actualIds, testing::UnorderedElementsAreArray(group.nodeIds));
 	};
@@ -792,4 +816,13 @@ TEST(MultipartOptimizer, TestBranchGroupings)
 	compareSupermesh(supermeshMap["branchGroup2"], expectedGroup2);
 	compareSupermesh(supermeshMap["branchGroup3"], expectedGroup3);
 	compareSupermesh(supermeshMap["branchGroup4"], expectedGroup4);
+
+	// Due to the large meshes and groupings, we expect a specific number of
+	// supermeshes
+
+	EXPECT_THAT(supermeshMap[""].size(), testing::Eq(5)); // 6 combined meshnodes, 2 combined "a", 1 "b", 1 from large split, 1 from large split
+	EXPECT_THAT(supermeshMap["branchGroup1"].size(), testing::Eq(5)); // 3 combined meshnodes, 1 from split, 1 from split, 1 from split, 1 from split
+	EXPECT_THAT(supermeshMap["branchGroup2"].size(), testing::Eq(3)); // 1 meshnode, 2x "a" and 1 "c"
+	EXPECT_THAT(supermeshMap["branchGroup3"].size(), testing::Eq(1)); // 2 combined meshnodes
+	EXPECT_THAT(supermeshMap["branchGroup4"].size(), testing::Eq(3)); // 4 combined meshnodes, 2 "a" and 1 "b"
 }

--- a/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
+++ b/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
@@ -670,7 +670,7 @@ TEST(MultipartOptimizer, TestBranchGroupings)
 			for (const auto& pair : mapping) {
 				actualIds.push_back(pair.mesh_id);
 
-				// MeshNode groups must not cross supermeshes
+				// MeshNode resource groupings must not cross supermeshes
 
 				const auto& meshNodeGrouping = group.nodeIdsToGrouping.at(pair.mesh_id);
 				if (!runningMeshNodeGrouping) {

--- a/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
+++ b/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <cstdlib>
 #include <repo/manipulator/modeloptimizer/repo_optimizer_multipart.h>
 #include <limits>
@@ -34,7 +35,6 @@ using namespace repo::test::utils::mesh;
 
 TEST(MultipartOptimizer, TestAllMerged)
 {
-	auto opt = MultipartOptimizer();
 
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
@@ -58,15 +58,12 @@ TEST(MultipartOptimizer, TestAllMerged)
 	
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -81,8 +78,6 @@ TEST(MultipartOptimizer, TestAllMerged)
 
 TEST(MultipartOptimizer, TestWithUV)
 {
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestWithUV";
@@ -113,15 +108,13 @@ TEST(MultipartOptimizer, TestWithUV)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -136,8 +129,6 @@ TEST(MultipartOptimizer, TestWithUV)
 
 TEST(MultipartOptimizer, TestMixedPrimitives)
 {
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestMixedPrimitives";
@@ -161,15 +152,13 @@ TEST(MultipartOptimizer, TestMixedPrimitives)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -202,8 +191,6 @@ TEST(MultipartOptimizer, TestMixedPrimitives)
 
 TEST(MultipartOptimizer, TestSingleLargeMesh)
 {
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestSingleLargeMesh";
@@ -223,15 +210,13 @@ TEST(MultipartOptimizer, TestSingleLargeMesh)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -246,8 +231,6 @@ TEST(MultipartOptimizer, TestSingleLargeMesh)
 
 TEST(MultipartOptimizer, TestSingleOversizedMesh)
 {
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestSingleOversizedMesh";
@@ -266,15 +249,13 @@ TEST(MultipartOptimizer, TestSingleOversizedMesh)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -289,8 +270,6 @@ TEST(MultipartOptimizer, TestSingleOversizedMesh)
 
 TEST(MultipartOptimizer, TestMultipleOversizedMeshes)
 {
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestMultipleOversizedMeshes";
@@ -309,16 +288,14 @@ TEST(MultipartOptimizer, TestMultipleOversizedMeshes)
 	sceneBuilder.finalise();
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
+	
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
 
-	bool result = opt.processScene(
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -334,8 +311,6 @@ TEST(MultipartOptimizer, TestMultipleOversizedMeshes)
 
 TEST(MultipartOptimizer, TestMultiplesMeshes)
 {
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestMultiplesMeshes";
@@ -360,15 +335,13 @@ TEST(MultipartOptimizer, TestMultiplesMeshes)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -383,8 +356,6 @@ TEST(MultipartOptimizer, TestMultiplesMeshes)
 
 TEST(MultipartOptimizer, TestMultipleSmallAndLargeMeshes)
 {
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestMultipleSmallAndLargeMeshes";
@@ -409,15 +380,13 @@ TEST(MultipartOptimizer, TestMultipleSmallAndLargeMeshes)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -430,8 +399,6 @@ TEST(MultipartOptimizer, TestMultipleSmallAndLargeMeshes)
 
 TEST(MultipartOptimizer, TestTinyMeshes)
 {
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestTinyMeshes";
@@ -452,15 +419,13 @@ TEST(MultipartOptimizer, TestTinyMeshes)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -481,10 +446,8 @@ TEST(MultipartOptimizer, TestTinyMeshes)
 		mockExporter.get()));
 }
 
-TEST(MultipartOptimizer, TestGroupings)
+TEST(MultipartOptimizer, TestMeshGroupings)
 {
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMULTIPARTOPTIMIZERTEST;
 	std::string projectName = "TestAllMerged";
@@ -508,15 +471,13 @@ TEST(MultipartOptimizer, TestGroupings)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -526,5 +487,213 @@ TEST(MultipartOptimizer, TestGroupings)
 		database,
 		projectName,
 		revId,
-		mockExporter.get()));
+		mockExporter.get())
+	);
+}
+
+#pragma optimize("", off)
+
+namespace {
+
+	// These methods are for use exclusively by TestBranchGroupings.
+
+	void createChildBranches(
+		repo::manipulator::modelutility::RepoSceneBuilder& sceneBuilder,
+		std::shared_ptr<repo::core::model::TransformationNode> parent,
+		int numChildren,
+		int depth,
+		std::unordered_map<std::string, repo::lib::RepoUUID>& nodes)
+	{
+		if (depth <= 0) {
+			return;
+		}
+		for (size_t i = 0; i < numChildren; ++i) {
+			auto name = parent->getName() + "_" + std::to_string(i);
+			auto child = sceneBuilder.addNode(
+				repo::core::model::RepoBSONFactory::makeTransformationNode({}, name, {parent->getSharedID()})
+			);
+			nodes[name] = child->getSharedID();
+			createChildBranches(sceneBuilder, child, numChildren, depth - 1, nodes);
+		}
+	}
+
+	void createMetadataNode(
+		repo::manipulator::modelutility::RepoSceneBuilder& sceneBuilder,
+		const repo::lib::RepoUUID& parentId,
+		const std::string& branchGroup)
+	{
+		std::unordered_map<std::string, repo::lib::RepoVariant> metadata;
+		metadata[REPO_METADATA_GROUPING_FLOOR] = repo::lib::RepoVariant(branchGroup);
+		sceneBuilder.addNode(
+			repo::core::model::RepoBSONFactory::makeMetaDataNode(metadata, {}, {parentId})
+		);
+	}
+}
+
+TEST(MultipartOptimizer, TestBranchGroupings)
+{
+	using namespace repo::core::model;
+	using namespace repo::manipulator::modelutility;
+
+	auto handler = getHandler();
+	std::string database = DBMULTIPARTOPTIMIZERTEST;
+	std::string projectName = "TestBranchGroupings";
+	auto revId = repo::lib::RepoUUID::createUUID();
+
+	auto sceneBuilder = RepoSceneBuilder(handler, database, projectName, revId);
+	auto rootNode = sceneBuilder.addNode(RepoBSONFactory::makeTransformationNode({}, "rootNode", {}));
+
+	// Creates a number of children under rootNode
+
+	auto nVertices = 10;
+
+	// Create a tree of sprawing branches. We will add meshes and metadata nodes to these.
+	// Each branch will have at least three children.
+
+	std::unordered_map<std::string, repo::lib::RepoUUID> nodes;
+	createChildBranches(sceneBuilder, rootNode, 4, 4, nodes);
+
+	// This type sets up the *expected* groupings
+
+	struct BranchGroup {
+		RepoSceneBuilder& sceneBuilder;
+
+		std::string name;
+		std::vector<repo::lib::RepoUUID> nodeIds;
+
+		std::unordered_map<repo::lib::RepoUUID, std::string, repo::lib::RepoUUIDHasher> nodeIdsToGrouping;
+
+		void addNode(std::unique_ptr<repo::core::model::MeshNode> node) {
+			nodeIds.push_back(node->getUniqueID());
+			nodeIdsToGrouping[node->getUniqueID()] = node->getGrouping();
+			if (node->getParentIDs().empty() || node->getParentIDs()[0].isDefaultValue()) {
+				throw repo::lib::RepoException("Mesh nodes must have a valid parent - in this test one of the hardcoded parent keys probably has a typo.");
+			}
+			sceneBuilder.addNode(std::move(node));
+		}
+	};
+
+	BranchGroup expectedGroupNull {sceneBuilder, ""};
+	BranchGroup expectedGroup1  {sceneBuilder, "branchGroup1"};
+	BranchGroup expectedGroup2  {sceneBuilder, "branchGroup2"};
+	BranchGroup expectedGroup3  {sceneBuilder, "branchGroup3"};
+	BranchGroup expectedGroup4  {sceneBuilder, "branchGroup4"};
+
+	// Meshes may belong to the root node (and should have the null group).
+
+	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "", {rootNode->getSharedID()}));
+	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "", {rootNode->getSharedID()}));
+	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "", {rootNode->getSharedID()}));
+
+	rootNode = nullptr; // Release rootnode or it won't be comitted.
+
+	// Meshes further down the tree, which have no grouping ancestor, should also
+	// be in the null group.
+
+	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_0"]}));
+	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_0_1_1"]}));
+	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_0_1_2_1"]}));
+
+	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "a", {nodes["rootNode_0"]}));
+	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "a", {nodes["rootNode_0_3"]}));
+	expectedGroupNull.addNode(createRandomMesh(nVertices, false, 3, "b", {nodes["rootNode_0_3_2_1"]}));
+
+	createMetadataNode(sceneBuilder, nodes["rootNode_1"], "branchGroup1");
+
+	// All mesh nodes under branch group 1 should be grouped together, regardless
+	// of depth.
+
+	expectedGroup1.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_1"]}));
+	expectedGroup1.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_1_1_1"]}));
+	expectedGroup1.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_1_1_2_1"]}));
+
+	// Branch group 3 should take precedence over branch group 2, for nodes
+	// further down.
+
+	createMetadataNode(sceneBuilder, nodes["rootNode_2"], "branchGroup2");
+	createMetadataNode(sceneBuilder, nodes["rootNode_2_1_2"], "branchGroup3");
+
+	expectedGroup2.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_2_1"]}));
+	expectedGroup3.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_2_1_2"]}));
+	expectedGroup3.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_2_1_2_0"]}));
+
+	// Branches are grouped by name, so even if their only common ancestor is far
+	// removed, they should still be grouped together.
+
+	createMetadataNode(sceneBuilder, nodes["rootNode_0_2"], "branchGroup4");
+	createMetadataNode(sceneBuilder, nodes["rootNode_2_2_2"], "branchGroup4");
+
+	expectedGroup4.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_0_2_0_0"]}));
+	expectedGroup4.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_0_2_2_0"]}));
+	expectedGroup4.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_2_2_2"]}));
+	expectedGroup4.addNode(createRandomMesh(nVertices, false, 3, "", {nodes["rootNode_2_2_2_1"]}));
+
+	// MeshNodes with a grouping should be in their own supermesh. They should
+	// always be in the same supermesh regardless of where they are in the tree,
+	// so long as they have the same branch group (which for these is null).
+
+	expectedGroup4.addNode(createRandomMesh(nVertices, false, 3, "a", {nodes["rootNode_0_2_1"]}));
+	expectedGroup4.addNode(createRandomMesh(nVertices, false, 3, "a", {nodes["rootNode_2_2_2_3"]}));
+	expectedGroup4.addNode(createRandomMesh(nVertices, false, 3, "b", {nodes["rootNode_2_2_2_1"]}));
+
+	expectedGroup2.addNode(createRandomMesh(nVertices, false, 3, "a", {nodes["rootNode_2_1_1_0"]}));
+	expectedGroup2.addNode(createRandomMesh(nVertices, false, 3, "c", {nodes["rootNode_2_1_3"]}));
+	expectedGroup2.addNode(createRandomMesh(nVertices, false, 3, "a", {nodes["rootNode_2_1_3_1"]}));
+
+	sceneBuilder.finalise();
+
+	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({0, 0, 0}));
+
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
+		database,
+		projectName,
+		revId
+	);
+
+	EXPECT_TRUE(mockExporter->isFinalised());
+
+	std::unordered_map<std::string, std::vector<const repo::core::model::SupermeshNode*>> supermeshMap; // By branch group
+
+	for (auto& sm : mockExporter->getSupermeshes()) {
+		supermeshMap[sm.getGrouping()].push_back(&sm);
+	}
+
+	auto compareSupermesh = [&](const std::vector<const repo::core::model::SupermeshNode*>& supermeshNodes, const BranchGroup& group) {
+		std::vector<repo::lib::RepoUUID> actualIds;
+		for (const auto& supermeshNode : supermeshNodes) {
+
+			std::optional<std::string> runningMeshNodeGrouping = std::nullopt;
+
+			auto mapping = supermeshNode->getMeshMapping();
+			for (const auto& pair : mapping) {
+				actualIds.push_back(pair.mesh_id);
+
+				// MeshNode groups must not cross supermeshes
+
+				const auto& meshNodeGrouping = group.nodeIdsToGrouping.at(pair.mesh_id);
+				if (!runningMeshNodeGrouping) {
+					runningMeshNodeGrouping = meshNodeGrouping;
+				}
+				else {
+					EXPECT_THAT(runningMeshNodeGrouping.value(), testing::Eq(meshNodeGrouping));
+				}
+			}
+
+			// A single grouping may have multiple supermeshes, because there is a lot of
+			// geometry, or because there are multiple MeshNode grouping entries (even
+			// though these will not be public).
+
+			EXPECT_THAT(supermeshNode->getGrouping(), testing::Eq(group.name));
+		}
+
+		EXPECT_THAT(actualIds, testing::UnorderedElementsAreArray(group.nodeIds));
+	};
+
+	compareSupermesh(supermeshMap[""], expectedGroupNull);
+	compareSupermesh(supermeshMap["branchGroup1"], expectedGroup1);
+	compareSupermesh(supermeshMap["branchGroup2"], expectedGroup2);
+	compareSupermesh(supermeshMap["branchGroup3"], expectedGroup3);
+	compareSupermesh(supermeshMap["branchGroup4"], expectedGroup4);
 }

--- a/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
+++ b/test/src/unit/repo/manipulator/modeloptimizer/ut_repo_optimizer_multipart.cpp
@@ -755,8 +755,7 @@ TEST(MultipartOptimizer, TestBranchGroupings)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({0, 0, 0}));
 
-	MultipartOptimizer opt(handler.get(), mockExporter.get());
-	opt.splitByFloor = true;
+	MultipartOptimizer opt(handler.get(), mockExporter.get(), true);
 	opt.processScene(
 		database,
 		projectName,

--- a/test/src/unit/repo/manipulator/modelutility/ut_repo_mesh_map_reorganiser.cpp
+++ b/test/src/unit/repo/manipulator/modelutility/ut_repo_mesh_map_reorganiser.cpp
@@ -36,8 +36,6 @@ TEST(MeshMapReorganiser, VeryLargeMesh)
 {
 	// This snippet creates a Supermesh using the Multipart Optimizer
 
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMESHMAPREORGANISERTEST;
 	std::string projectName = "VeryLargeMesh";
@@ -55,15 +53,13 @@ TEST(MeshMapReorganiser, VeryLargeMesh)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -119,8 +115,6 @@ TEST(MeshMapReorganiser, MultipleTinyMeshes)
 {
 	// This snippet creates a Supermesh using the Multipart Optimizer
 
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMESHMAPREORGANISERTEST;
 	std::string projectName = "InterleavedMixedSplit";
@@ -147,15 +141,13 @@ TEST(MeshMapReorganiser, MultipleTinyMeshes)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 
@@ -223,8 +215,6 @@ TEST(MeshMapReorganiser, InterleavedMixedSplit)
 	// Create a supermesh that contains a mix of small meshes, and large meshes
 	// that will need to be split.
 
-	auto opt = MultipartOptimizer();
-
 	auto handler = getHandler();
 	std::string database = DBMESHMAPREORGANISERTEST;
 	std::string projectName = "InterleavedMixedSplit";
@@ -262,15 +252,13 @@ TEST(MeshMapReorganiser, InterleavedMixedSplit)
 
 	auto mockExporter = std::make_unique<TestModelExport>(handler.get(), database, projectName, revId, std::vector<double>({ 0, 0, 0 }));
 
-	bool result = opt.processScene(
+	MultipartOptimizer opt(handler.get(), mockExporter.get());
+
+	opt.processScene(
 		database,
 		projectName,
-		revId,
-		handler.get(),
-		mockExporter.get()
+		revId
 	);
-
-	EXPECT_TRUE(result);
 
 	EXPECT_TRUE(mockExporter->isFinalised());
 

--- a/test/src/unit/repo_test_mesh_utils.h
+++ b/test/src/unit/repo_test_mesh_utils.h
@@ -123,7 +123,7 @@ namespace repo {
 						return finalised;
 					};
 
-					std::vector<repo::core::model::SupermeshNode> getSupermeshes() {
+					const std::vector<repo::core::model::SupermeshNode>& getSupermeshes() {
 						return supermeshNodes;
 					};
 

--- a/test/src/unit/repo_test_mesh_utils.h
+++ b/test/src/unit/repo_test_mesh_utils.h
@@ -149,15 +149,15 @@ namespace repo {
 						// Do nothing else
 					};
 
-					bool isFinalised() {
+					bool isFinalised() const {
 						return finalised;
 					};
 
-					const std::vector<repo::core::model::SupermeshNode>& getSupermeshes() {
+					const std::vector<repo::core::model::SupermeshNode>& getSupermeshes() const {
 						return supermeshNodes;
 					};
 
-					int getSupermeshCount() {
+					int getSupermeshCount() const {
 						return supermeshNodes.size();
 					};
 


### PR DESCRIPTION
This fixes #842

#### Description
This PR adds support for splitting up mesh nodes into bundles based on the tree, as well as resource ids (meshnode grouping members). Additionally, when split by branch, the bundles are tagged.

The purpose is to allow downloading just some floors in offline mode, though for now the feature is on by default meaning models can be used offline post-hoc.

The way it works is that when a transformation node that represents the tip of a branch corresponding to a floor/level is encountered, a magic metadata parameter is added to it. Currently this is done for IFC, RVT and NWD files.

Later on, during optimisation, mesh nodes are grouped based on whether they are descendants of one of these nodes. Nodes are split by both branch and resource groups.

In the future, this stage could be extended to support grouping by other metadata queries (e.g. to cut up long linear infrastructure models).

To support this, the `clusterAndSupermesh` method has been modified so it that performs the grouping, rather than jobs being built around mesh node groups. Additionally, the grouping member has been added to the SupermeshNode type (for output to the assets document), and the optimiser has been updated to pass this on.

All grouping operations take place in `clusterAndSupermesh`, allowing the grouping behaviour to updated easily in the future.

Finally, a few quality of life improvements are made: the combine_hash function has been moved into a header, the repo queries have been updated to avoid the const char* converting to bool issue happening, and the streaming mesh node fails fast  & early with a nested exception if its contents are accessed before it is loaded.