### PR TITLE
Issue 863 Fix Bug Causing Incorrect Model Coordinates

### DIFF
--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/file_processor_rvt.cpp
@@ -415,7 +415,7 @@ OdGeMatrix3d getModelToWorldMatrix(OdBmDatabasePtr pDb)
 
 				OdBmGeoLocationPtr pActiveLocation = OdBmGeoLocation::getActiveLocationId(pThis->database()).safeOpenObject();
 				OdGeMatrix3d activeTransform = pActiveLocation->getTransform();
-				activeTransform.inverse();
+				activeTransform.invert();
 
 				return activeTransform;
 			}

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -642,12 +642,11 @@ TEST(ODAModelImport, RvtSurveyPoint)
 	config.targetUnits = ModelUnits::MILLIMETRES;
 
 	auto scene = ODAModelImportUtils::ModelImportManagerImport(getDataPath("sample2026.rvt"), config);
-	// SceneUtils scene(scene);
 
 	auto offset = scene->getWorldOffset();
-	EXPECT_THAT(offset[0], Eq(expectedOffset[0]));
-	EXPECT_THAT(offset[1], Eq(expectedOffset[1]));
-	EXPECT_THAT(offset[2], Eq(expectedOffset[2]));
+	EXPECT_THAT(offset[0], DoubleNear(expectedOffset[0], 1e-8));
+	EXPECT_THAT(offset[1], DoubleNear(expectedOffset[1], 1e-8));
+	EXPECT_THAT(offset[2], DoubleNear(expectedOffset[2], 1e-8));
 }
 
 TEST_F(NwdTestSuite, MetadataParentsNWD)

--- a/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
+++ b/test/src/unit/repo/manipulator/modelconvertor/import/odaImport/ut_repo_model_import_oda.cpp
@@ -624,6 +624,32 @@ TEST(ODAModelImport, RvtUnits)
 	}
 }
 
+TEST(ODAModelImport, RvtSurveyPoint)
+{
+	std::vector<double> expectedOffset{
+		12309582.429912938,
+		0.0,
+		-123914605.28981794
+	};
+
+	::setupTextures();
+	
+	ModelImportConfig config(
+		repo::lib::RepoUUID::createUUID(),
+		TESTDB,
+		"RvtSurveyPoint"
+	);
+	config.targetUnits = ModelUnits::MILLIMETRES;
+
+	auto scene = ODAModelImportUtils::ModelImportManagerImport(getDataPath("sample2026.rvt"), config);
+	// SceneUtils scene(scene);
+
+	auto offset = scene->getWorldOffset();
+	EXPECT_THAT(offset[0], Eq(expectedOffset[0]));
+	EXPECT_THAT(offset[1], Eq(expectedOffset[1]));
+	EXPECT_THAT(offset[2], Eq(expectedOffset[2]));
+}
+
 TEST_F(NwdTestSuite, MetadataParentsNWD)
 {
 	// All metadata nodes must also have their sibling meshnodes as parents,

--- a/test/src/unit/repo/manipulator/modelutility/ut_repo_clash_detection.cpp
+++ b/test/src/unit/repo/manipulator/modelutility/ut_repo_clash_detection.cpp
@@ -959,10 +959,38 @@ TEST(Clash, SupportedRanges)
 		ClashDetectionConfigHelper config;
 		config.type = ClashDetectionType::Clearance;
 		MockClashScene scene(config.getRevision());
-		scene.add(clashGenerator.createTrianglesVF(
-			repo::lib::RepoBounds({ repo::lib::RepoVector3D64(0, 0, 0) })),
-			config
-		);
+
+		// The RNG can come up with a problem where the vertices are actually all within the limit.
+		// This ensures that we will always have a valid problem.
+		bool foundValidProblem = false;
+		do {
+			auto triangles = clashGenerator.createTrianglesVF(
+				repo::lib::RepoBounds({ repo::lib::RepoVector3D64(0, 0, 0) }));
+
+			auto triangleA = triangles.a.e;
+			auto matA = triangles.a.m;
+
+			auto triangleB = triangles.b.e;
+			auto matB = triangles.b.m;
+
+			std::vector<repo::lib::RepoVector3D64> vertices;
+			vertices.push_back(matA * triangleA.a);
+			vertices.push_back(matA * triangleA.b);
+			vertices.push_back(matA * triangleA.c);
+			vertices.push_back(matB * triangleB.a);
+			vertices.push_back(matB * triangleB.b);
+			vertices.push_back(matB * triangleB.c);
+
+			for (auto& v : vertices)
+			{
+				if ((std::abs(v.x) > MESH_LIMIT) || (std::abs(v.y) > MESH_LIMIT) || (std::abs(v.z) > MESH_LIMIT))
+				{
+					foundValidProblem = true;
+					scene.add(triangles, config);
+					break;
+				}
+			}
+		} while (!foundValidProblem);
 
 		db->setDocuments(scene.bsons);
 


### PR DESCRIPTION
This fixes #863

#### Description
<!-- Add a high level description of the changes made (possibly quite similar to task list if it was a feature) 
e.g.
- Support new error codes
- Changed wording of some error codes
- Removed unused error codes
- Replaced some error codes that are irrelevant to user (e.g. if bouncer failed to launch, we shouldn't tell the user about it, it should just tell them the process failed)
- Add bouncer error code to email notification for better referencing.
- Changed some response codes from 500 to 400 (e.g. user uploading a file with no mesh is a user error, not system's)
-->

It was found that the cause was a method call renamed by accident in a previous commit in the code that applies the offset from the survey point in Revit. This was not caught by existing unit tests since there are none that check the models position or the influence of its survey point.

The code change was reversed and a unit test added that checks the offset after a model with a survey point is imported.

