### PR TITLE
ISSUE #873 remove validation check from runNTasks entry point

### DIFF
--- a/tools/bouncer_worker/src/lib/queueHandler.js
+++ b/tools/bouncer_worker/src/lib/queueHandler.js
@@ -209,9 +209,6 @@ QueueHandler.connectToQueue = async (specificQueue) => {
 QueueHandler.runNTasks = async (queueType, nTasks) => {
 	const queueName = getQueueName(queueType);
 	const handler = queueHandlers[queueName];
-	if (!handler.validateConfiguration(logLabel)) {
-		exitApplication();
-	}
 	connectToRabbitMQ(false, (conn) => executeTasks(conn, queueName, nTasks, handler.onMessageReceived));
 };
 


### PR DESCRIPTION
This fixes #873

Removes a check now performed by yup that was calling a non-existent method
