### PR TITLE
ISSUE #875 - Update staging bouncer Helm chart version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 # IMAGE_TAG is derived from the branch name of the triggering build
 
 env:
-  HELM_CHART_VERSION: '5.22.2'
+  HELM_CHART_VERSION: '5.23.0'
   IMAGE_TAG: ${{ github.event.workflow_run.head_branch }}
 
 jobs:


### PR DESCRIPTION
This fixes #875

#### Description
Updates the staging deploy workflow to use bouncer Helm chart version 5.23.0 from DevOps.

#### Acceptance Criteria
Staging deploy workflow references HELM_CHART_VERSION 5.23.0.