### PR TITLE
ISSUE #875 - Run staging deploy from build workflow

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       build_id:
-        description: "Build workflow run ID to annotate pods with."
+        description: "Commit SHA to annotate pods with."
         required: true
         type: string
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,27 @@
 name: Deploy Bouncer to Staging
 
 on:
-  workflow_run:
-    workflows: ["Build and Push Bouncer"]
-    types: [completed]
-    branches: [staging]
+  workflow_call:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy."
+        required: true
+        type: string
+      build_id:
+        description: "Build workflow run ID to annotate pods with."
+        required: true
+        type: string
+    secrets:
+      KUBE_CONFIG_STAGING:
+        required: true
+      PROJ_MANAGEMENT_TOKEN:
+        required: true
+      REGISTRY_LOGIN_SERVER:
+        required: true
+      REGISTRY_TOKEN:
+        required: true
+      REGISTRY_USERNAME:
+        required: true
 
 permissions:
   contents: read
@@ -13,16 +30,16 @@ concurrency:
   group: deploy-staging
   cancel-in-progress: false
 
-# Update HELM_CHART_VERSION here when the bouncer helm chart is bumped in DevOps.
-# IMAGE_TAG is derived from the branch name of the triggering build
+# Update HELM_CHART_VERSION when the bouncer chart is bumped in DevOps.
+# IMAGE_TAG is passed by the build workflow
 
 env:
   HELM_CHART_VERSION: '5.23.0'
-  IMAGE_TAG: ${{ github.event.workflow_run.head_branch }}
+  IMAGE_TAG: ${{ inputs.image_tag }}
+  BUILD_ID: ${{ inputs.build_id }}
 
 jobs:
   deploy:
-    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -75,7 +92,7 @@ jobs:
             -f deployments/asite-stg/helm/bouncer/values.yaml \
             --set image.tag=${{ env.IMAGE_TAG }} \
             --set rollingupdate.enabled=true \
-            --set-string podAnnotations.buildId=${{ github.event.workflow_run.id }} \
+            --set-string podAnnotations.buildId=${{ env.BUILD_ID }} \
             --wait \
             --rollback-on-failure
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,17 +11,6 @@ on:
         description: "Build workflow run ID to annotate pods with."
         required: true
         type: string
-    secrets:
-      KUBE_CONFIG_STAGING:
-        required: true
-      PROJ_MANAGEMENT_TOKEN:
-        required: true
-      REGISTRY_LOGIN_SERVER:
-        required: true
-      REGISTRY_TOKEN:
-        required: true
-      REGISTRY_USERNAME:
-        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/dockerBuildAndPush.yml
+++ b/.github/workflows/dockerBuildAndPush.yml
@@ -99,7 +99,7 @@ jobs:
 
           if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
             VERSION="${GITHUB_REF##*/}"
-            CHECKOUT_REF="${GITHUB_REF}"
+            CHECKOUT_REF="${GITHUB_SHA}"
           elif [[ "${GITHUB_EVENT_NAME}" == "issue_comment" ]]; then
             # For PR comments, we need to get the PR branch name for the version tag
             ISSUE_NUMBER=$(jq -r .issue.number < "$GITHUB_EVENT_PATH")

--- a/.github/workflows/dockerBuildAndPush.yml
+++ b/.github/workflows/dockerBuildAndPush.yml
@@ -15,7 +15,7 @@ permissions:
 
 concurrency:
   group: build-${{ github.event_name }}-${{ github.event_name == 'issue_comment' && github.event.issue.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/staging' }}
 
 jobs:
   pre-build:
@@ -141,8 +141,8 @@ jobs:
       - pre-build
       - build-push
     if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
-    uses: ./.github/workflows/deploy.yml
+    uses: ./.github/workflows/_deploy.yml
     with:
       image_tag: ${{ needs.pre-build.outputs.version }}
-      build_id: ${{ github.run_id }}
+      build_id: ${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/dockerBuildAndPush.yml
+++ b/.github/workflows/dockerBuildAndPush.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           ORG="3drepo"
           USER="${{ github.actor }}"
-          
+
           echo "Checking if $USER belongs to $ORG..."
 
           # Check if the user is a member of the organization (including private members)
@@ -106,7 +106,7 @@ jobs:
             VERSION=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github+json" \
               "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/$ISSUE_NUMBER" | jq -r .head.ref)
-            
+
             if [ "$VERSION" = "null" ] || [ -z "$VERSION" ]; then
               echo "Failed to get PR branch name"
               exit 1
@@ -134,4 +134,15 @@ jobs:
       version: ${{ needs.pre-build.outputs.version }}
       app_build_now: ${{ needs.pre-build.outputs.app_build_now }}
       push: true
+    secrets: inherit
+
+  deploy-staging:
+    needs:
+      - pre-build
+      - build-push
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    uses: ./.github/workflows/deploy.yml
+    with:
+      image_tag: ${{ needs.pre-build.outputs.version }}
+      build_id: ${{ github.run_id }}
     secrets: inherit


### PR DESCRIPTION
This fixes #875

#### Description
Changes staging deployment so it is called directly from the staging build-and-push workflow after the image is pushed. This avoids GitHub Actions workflow_run using the default-branch deploy workflow while the upstream build came from staging.

#### Acceptance Criteria
A push to staging builds and pushes the staging bouncer image, then deploys using the deploy workflow from the same staging ref and Helm chart version 5.23.0.