### PR TITLE
ISSUE #881 throw exceptions not pointers

### DIFF
--- a/bouncer/src/repo/lib/CMakeLists.txt
+++ b/bouncer/src/repo/lib/CMakeLists.txt
@@ -22,6 +22,7 @@ set(HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/json_parser_write.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_config.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_exception.h
+	${CMAKE_CURRENT_SOURCE_DIR}/repo_hash_combine.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_json_parser.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_license.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_property_tree.h

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/repo_mesh_builder.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/repo_mesh_builder.cpp
@@ -54,7 +54,7 @@ repo_material_t RepoMeshBuilder::getMaterial()
 RepoMeshBuilder::~RepoMeshBuilder()
 {
 	// extractMeshes *must* be called, because there is where the mesh data instances are deleted/cleaned up.
-	if (meshes.size()) {
+	if (meshes.size() && !std::uncaught_exceptions()) {
 		throw repo::lib::RepoGeometryProcessingException("RepoMeshBuilder destroyed with meshes that have not been extracted.");
 	}
 }

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/repo_mesh_builder.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/repo_mesh_builder.cpp
@@ -259,7 +259,7 @@ void RepoMeshBuilder::extractMeshes(std::vector<MeshNode>& nodes, const repo::li
 
 		if (meshData->vertexMap.uvs.size() && (meshData->vertexMap.uvs.size() != meshData->vertexMap.vertices.size()))
 		{
-			throw new repo::lib::RepoGeometryProcessingException("RepoMeshBuilder mesh_data_t vertices size does not match the uvs size");
+			throw repo::lib::RepoGeometryProcessingException("RepoMeshBuilder mesh_data_t vertices size does not match the uvs size");
 		}
 
 		auto uvChannels = meshData->vertexMap.uvs.size() ?
@@ -271,7 +271,7 @@ void RepoMeshBuilder::extractMeshes(std::vector<MeshNode>& nodes, const repo::li
 		if (meshData->vertexMap.normals.size()) {
 			if ((meshData->vertexMap.normals.size() != meshData->vertexMap.vertices.size()))
 			{
-				throw new repo::lib::RepoGeometryProcessingException("RepoMeshBuilder mesh_data_t vertices size does not match the normals size, where normals are required.");
+				throw repo::lib::RepoGeometryProcessingException("RepoMeshBuilder mesh_data_t vertices size does not match the normals size, where normals are required.");
 			}
 
 			normals32.reserve(meshData->vertexMap.normals.size());

--- a/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/repo_mesh_builder.cpp
+++ b/bouncer/src/repo/manipulator/modelconvertor/import/odaHelper/repo_mesh_builder.cpp
@@ -115,7 +115,8 @@ RepoMeshBuilder::face::face(std::initializer_list<repo::lib::RepoVector3D64> ver
 	setVertices(vertices);
 }
 
-RepoMeshBuilder::face::face(std::initializer_list<repo::lib::RepoVector3D64> vertices, repo::lib::RepoVector3D64 normal)
+RepoMeshBuilder::face::face(std::initializer_list<repo::lib::RepoVector3D64> vertices, repo::lib::RepoVector3D64 normal) :
+	face()
 {
 	setVertices(vertices);
 	this->norm = normal;

--- a/bouncer/src/repo/manipulator/modelutility/CMakeLists.txt
+++ b/bouncer/src/repo/manipulator/modelutility/CMakeLists.txt
@@ -30,5 +30,6 @@ set(HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_mesh_map_reorganiser.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_scene_builder.h
 	${CMAKE_CURRENT_SOURCE_DIR}/repo_scene_manager.h
+	${CMAKE_CURRENT_SOURCE_DIR}/repo_web_buffer_config.h
 	CACHE STRING "HEADERS" FORCE)
 


### PR DESCRIPTION
This fixes #881 - an NWD importer regression that was showing up only in Docker.

The actual fix is in the `RepoMeshBuilder::face::face(std::initializer_list<repo::lib::RepoVector3D64> vertices, repo::lib::RepoVector3D64 normal)` constructor, which was not calling the overload that initialises `numUvs`, like the others.

Though in investigating this a couple of other minor issues were resolved and fixed:

1. RepoMeshBuilder no longer throws if already inside an exception handler, because that would lose the original exception.
2. RepoMeshBuilder throws objects instead of pointers, as throwing pointers is not correct.
3. CMAKE files that should have already been updated are committed.

There are no regression tests added because this is was not a logic error as such and so the only way to find such a bug would have been with valgrind, etc.
