### PR TITLE
ISSUE #887 - pin CI mongo to 8.0.28

### DIFF
--- a/.github/workflows/runUnitAndIntegrationTests.yml
+++ b/.github/workflows/runUnitAndIntegrationTests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.1
         with:
-          mongodb-version: 8.0
+          mongodb-version: 8.0.28
           mongodb-username: testUser
           mongodb-password: 3drepotest
 


### PR DESCRIPTION
This fixes #887

#### Description
Pin the CI MongoDB version to 8.0.28

#### Acceptance Criteria
- Run Unit and Integration Tests passes on 8.0.28