### PR TITLE
ISSUE #898 update system information and uuid

### DIFF
--- a/tools/bouncer_worker/package.json
+++ b/tools/bouncer_worker/package.json
@@ -19,9 +19,9 @@
     "crypto-js": "4.2.0",
     "moment": "2.30.1",
     "nodemon": "3.1.9",
-    "systeminformation": "5.25.11",
+    "systeminformation": "5.33.1",
     "tree-kill": "1.2.2",
-    "uuid": "8.3.2",
+    "uuid": "11.1.1",
     "winston": "3.17.0",
     "yargs": "16.2.0",
     "yup": "1.6.1"

--- a/tools/bouncer_worker/yarn.lock
+++ b/tools/bouncer_worker/yarn.lock
@@ -1957,10 +1957,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-systeminformation@5.25.11:
-  version "5.25.11"
-  resolved "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz"
-  integrity sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g==
+systeminformation@5.33.1:
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.33.1.tgz#499f06a859d2abeafaae6d69f71dd3516919f0f4"
+  integrity sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==
 
 table@^5.2.3:
   version "5.4.6"
@@ -2121,10 +2121,10 @@ util-deprecate@^1.0.1:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-compile-cache@^2.0.3:
   version "2.4.0"


### PR DESCRIPTION
This fixes #898

#### Description
| Library | Old Version | Upgraded To | CVE-Free Confirmed (OSV)? | Notes |
|---|---|---|---|---|
| systeminformation | 5.25.11 | 5.33.1 (latest) | Yes | Old ver hit GHSA-5vv4-hvf7-2h46 (cmd injection via `locate` output in `versions()`, Linux). Latest still `type: commonjs`; `require('systeminformation')` unchanged. `osInfo()`/`mem()` calls in `processMonitor.js` work as-is, no code change needed. |
| uuid | 8.3.2 | 11.1.1 (not latest 14.0.1) | Yes | Old ver hit GHSA-w5hq-g745-h8pq (buffer bounds check v3/v5/v6). Latest (v12/13/14) dropped CJS export condition — ESM-only, breaks `require('uuid')`. v11.1.1 = last release w/ CJS `require` condition in exports map, verified CVE-free, works with existing `const { v4: uuidv4 } = require('uuid')` in `config.js`. |

#### Acceptance Criteria
application should work as before